### PR TITLE
feat: add last_terminal_tab tracking for improved tab focus management

### DIFF
--- a/crates/oryxis-app/src/app.rs
+++ b/crates/oryxis-app/src/app.rs
@@ -96,6 +96,9 @@ pub struct Oryxis {
     // Tabs
     pub(crate) tabs: Vec<TerminalTab>,
     pub(crate) active_tab: Option<usize>,
+    /// Last terminal tab that had focus. Preserved when switching to nav-only
+    /// views (Snippets, Keys, …) so snippet injection still targets that session.
+    pub(crate) last_terminal_tab: Option<usize>,
     pub(crate) hovered_tab: Option<usize>,
     pub(crate) show_new_tab_picker: bool,
     pub(crate) new_tab_picker_search: String,
@@ -516,6 +519,36 @@ pub struct Oryxis {
 // `boot`, `load_data_from_vault`, `persist_setting` live in `crate::boot`.
 
 impl Oryxis {
+    pub(crate) fn snippet_injection_tab(&self) -> Option<usize> {
+        let idx = self.active_tab.or(self.last_terminal_tab)?;
+        (idx < self.tabs.len()).then_some(idx)
+    }
+
+    pub(crate) fn remember_terminal_tab_focus(&mut self, idx: usize) {
+        if idx < self.tabs.len() {
+            self.last_terminal_tab = Some(idx);
+        }
+    }
+
+    pub(crate) fn adjust_last_terminal_tab_after_remove(&mut self, removed_idx: usize) {
+        if self.tabs.is_empty() {
+            self.last_terminal_tab = None;
+            return;
+        }
+        match self.last_terminal_tab {
+            Some(l) if l == removed_idx => {
+                self.last_terminal_tab = Some(removed_idx.min(self.tabs.len() - 1));
+            }
+            Some(l) if l > removed_idx => {
+                self.last_terminal_tab = Some(l - 1);
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn clear_terminal_tab_memory(&mut self) {
+        self.last_terminal_tab = None;
+    }
 
     pub fn title(&self) -> String {
         "Oryxis".into()

--- a/crates/oryxis-app/src/boot.rs
+++ b/crates/oryxis-app/src/boot.rs
@@ -90,6 +90,7 @@ impl Oryxis {
                 sidebar_collapsed: false,
                 tabs: Vec::new(),
                 active_tab: None,
+                last_terminal_tab: None,
                 hovered_tab: None,
                 show_new_tab_picker: false,
                 new_tab_picker_search: String::new(),

--- a/crates/oryxis-app/src/dispatch.rs
+++ b/crates/oryxis-app/src/dispatch.rs
@@ -261,14 +261,15 @@ impl Oryxis {
             Message::RunSnippet(idx) => {
                 if let Some(snip) = self.snippets.get(idx) {
                     let cmd = format!("{}\n", snip.command);
-                    if let Some(tab_idx) = self.active_tab
-                        && let Some(tab) = self.tabs.get(tab_idx) {
-                            if let Some(ref ssh) = tab.active().ssh_session {
-                                let _ = ssh.write(cmd.as_bytes());
-                            } else if let Ok(mut state) = tab.active().terminal.lock() {
-                                state.write(cmd.as_bytes());
-                            }
+                    if let Some(tab_idx) = self.snippet_injection_tab()
+                        && let Some(tab) = self.tabs.get(tab_idx)
+                    {
+                        if let Some(ref ssh) = tab.active().ssh_session {
+                            let _ = ssh.write(cmd.as_bytes());
+                        } else if let Ok(mut state) = tab.active().terminal.lock() {
+                            state.write(cmd.as_bytes());
                         }
+                    }
                 }
             }
 

--- a/crates/oryxis-app/src/dispatch_cloud/mod.rs
+++ b/crates/oryxis-app/src/dispatch_cloud/mod.rs
@@ -135,6 +135,7 @@ impl Oryxis {
                     Arc::new(Mutex::new(state)),
                 ));
                 self.active_tab = Some(tab_idx);
+                self.remember_terminal_tab_focus(tab_idx);
                 self.active_view = View::Terminal;
                 let stream = UnboundedReceiverStream::new(rx);
                 Task::batch(vec![

--- a/crates/oryxis-app/src/dispatch_settings.rs
+++ b/crates/oryxis-app/src/dispatch_settings.rs
@@ -375,6 +375,7 @@ impl Oryxis {
                         self.groups.clear();
                         self.tabs.clear();
                         self.active_tab = None;
+                        self.clear_terminal_tab_memory();
                         self.active_view = View::Dashboard;
                     } else {
                         // No user password: re-open immediately
@@ -464,6 +465,7 @@ fn spawn_local_shell(
                 Arc::new(Mutex::new(state)),
             ));
             app.active_tab = Some(tab_idx);
+            app.remember_terminal_tab_focus(tab_idx);
             app.active_view = View::Terminal;
             let stream = UnboundedReceiverStream::new(rx);
             Task::batch(vec![

--- a/crates/oryxis-app/src/dispatch_ssh.rs
+++ b/crates/oryxis-app/src/dispatch_ssh.rs
@@ -160,6 +160,7 @@ impl Oryxis {
                                 tab_idx,
                             });
                             self.active_tab = Some(tab_idx);
+                            self.remember_terminal_tab_focus(tab_idx);
 
                             // Host key verification: check callback + ask channel
                             let known_hosts_snapshot: Arc<Mutex<Vec<oryxis_core::models::known_host::KnownHost>>> =
@@ -788,6 +789,7 @@ impl Oryxis {
                     let tab_idx = progress.tab_idx;
                     if tab_idx < self.tabs.len() {
                         self.tabs.remove(tab_idx);
+                        self.adjust_last_terminal_tab_after_remove(tab_idx);
                     }
                 }
                 self.connecting = None;
@@ -801,6 +803,7 @@ impl Oryxis {
                     self.connecting = None;
                     if tab_idx < self.tabs.len() {
                         self.tabs.remove(tab_idx);
+                        self.adjust_last_terminal_tab_after_remove(tab_idx);
                     }
                     self.active_tab = None;
                     self.active_view = View::Dashboard;
@@ -814,6 +817,7 @@ impl Oryxis {
                     self.connecting = None;
                     if tab_idx < self.tabs.len() {
                         self.tabs.remove(tab_idx);
+                        self.adjust_last_terminal_tab_after_remove(tab_idx);
                     }
                     self.active_tab = None;
                     return Ok(self.update(Message::ConnectSsh(idx)));

--- a/crates/oryxis-app/src/dispatch_tabs.rs
+++ b/crates/oryxis-app/src/dispatch_tabs.rs
@@ -211,6 +211,7 @@ impl Oryxis {
             Message::SelectTab(idx) => {
                 if idx < self.tabs.len() {
                     self.active_tab = Some(idx);
+                    self.remember_terminal_tab_focus(idx);
                     self.active_view = View::Terminal;
                     return Ok(self.tab_scroll_to_active());
                 }
@@ -330,11 +331,14 @@ impl Oryxis {
                 self.overlay = None;
                 if idx < self.tabs.len() {
                     self.tabs.remove(idx);
+                    self.adjust_last_terminal_tab_after_remove(idx);
                     if self.tabs.is_empty() {
                         self.active_tab = None;
                         self.active_view = View::Dashboard;
                     } else {
-                        self.active_tab = Some(idx.min(self.tabs.len() - 1));
+                        let i = idx.min(self.tabs.len() - 1);
+                        self.active_tab = Some(i);
+                        self.remember_terminal_tab_focus(i);
                     }
                 }
             }
@@ -354,11 +358,14 @@ impl Oryxis {
                     let base_label = tab.label.trim_end_matches(" (disconnected)").to_string();
                     let conn_idx = self.connections.iter().position(|c| c.label == base_label);
                     self.tabs.remove(idx);
+                    self.adjust_last_terminal_tab_after_remove(idx);
                     if self.tabs.is_empty() {
                         self.active_tab = None;
                         self.active_view = View::Dashboard;
                     } else {
-                        self.active_tab = Some(idx.min(self.tabs.len() - 1));
+                        let i = idx.min(self.tabs.len() - 1);
+                        self.active_tab = Some(i);
+                        self.remember_terminal_tab_focus(i);
                     }
                     if let Some(ci) = conn_idx {
                         // Toast "Reconnecting..." so the user sees feedback the
@@ -538,12 +545,14 @@ impl Oryxis {
                     self.tabs.clear();
                     self.tabs.push(keep);
                     self.active_tab = Some(0);
+                    self.remember_terminal_tab_focus(0);
                 }
             }
             Message::CloseAllTabs => {
                 self.overlay = None;
                 self.tabs.clear();
                 self.active_tab = None;
+                self.clear_terminal_tab_memory();
                 self.active_view = View::Dashboard;
             }
 


### PR DESCRIPTION
- Introduced `last_terminal_tab` to store the last focused terminal tab, enhancing snippet injection targeting.
- Implemented methods to remember tab focus, adjust focus after tab removal, and clear focus memory.
- Updated relevant dispatch logic to utilize the new focus management features across tab interactions.