### PR TITLE
feat: vault master password — show / hide (eye toggle)

### DIFF
--- a/crates/oryxis-app/src/app.rs
+++ b/crates/oryxis-app/src/app.rs
@@ -78,6 +78,7 @@ pub struct Oryxis {
     pub(crate) vault: Option<VaultStore>,
     pub(crate) vault_state: VaultState,
     pub(crate) vault_password_input: String,
+    pub(crate) vault_password_visible: bool,
     pub(crate) vault_error: Option<String>,
     pub(crate) logo_handle: image::Handle,
     pub(crate) logo_small_handle: image::Handle,

--- a/crates/oryxis-app/src/boot.rs
+++ b/crates/oryxis-app/src/boot.rs
@@ -78,6 +78,7 @@ impl Oryxis {
                 vault,
                 vault_state,
                 vault_password_input: String::new(),
+                vault_password_visible: false,
                 vault_error: None,
                 logo_handle: image::Handle::from_bytes(include_bytes!("../../../resources/logo_128.png").as_slice()),
                 logo_small_handle: image::Handle::from_bytes(include_bytes!("../../../resources/logo_64.png").as_slice()),

--- a/crates/oryxis-app/src/dispatch.rs
+++ b/crates/oryxis-app/src/dispatch.rs
@@ -53,6 +53,9 @@ impl Oryxis {
             Message::VaultPasswordChanged(pw) => {
                 self.vault_password_input = pw;
             }
+            Message::VaultTogglePasswordVisibility => {
+                self.vault_password_visible = !self.vault_password_visible;
+            }
             Message::VaultSetup => {
                 if self.vault_password_input.len() < 4 {
                     self.vault_error = Some("Password must be at least 4 characters".into());
@@ -68,6 +71,7 @@ impl Oryxis {
                             // Cache for child-window spawn.
                             self.master_password = Some(self.vault_password_input.clone());
                             self.vault_password_input.clear();
+                            self.vault_password_visible = false;
                             self.load_data_from_vault();
                         }
                         Err(e) => {
@@ -106,6 +110,7 @@ impl Oryxis {
                             self.vault_error = None;
                             self.vault_destroy_confirm = false;
                             self.vault_password_input.clear();
+                            self.vault_password_visible = false;
                         }
                         Err(e) => {
                             self.vault_error = Some(format!("Failed to reset vault: {}", e));
@@ -123,6 +128,7 @@ impl Oryxis {
                             // child windows with it via stdin pipe.
                             self.master_password = Some(self.vault_password_input.clone());
                             self.vault_password_input.clear();
+                            self.vault_password_visible = false;
                             self.load_data_from_vault();
                             // After a manual unlock, fire any deferred
                             // `--connect <uuid>` from the launch CLI args.

--- a/crates/oryxis-app/src/messages.rs
+++ b/crates/oryxis-app/src/messages.rs
@@ -18,6 +18,7 @@ use crate::state::{ConnectionStep, SettingsSection, View};
 pub enum Message {
     // Vault
     VaultPasswordChanged(String),
+    VaultTogglePasswordVisibility,
     VaultUnlock,
     VaultSetup,
     VaultSkipPassword,

--- a/crates/oryxis-app/src/views/vault.rs
+++ b/crates/oryxis-app/src/views/vault.rs
@@ -8,7 +8,7 @@ use iced::{Background, Border, Color, Element, Length, Padding};
 use crate::app::{Message, Oryxis};
 use crate::theme::OryxisColors;
 use crate::views::chrome::window_chrome_bar;
-use crate::widgets::styled_button;
+use crate::widgets::{dir_row, styled_button};
 
 /// Wrap a vault screen body with the top window chrome so the user can still
 /// drag / minimize / maximize / close before unlocking the vault. Also adds
@@ -32,6 +32,41 @@ fn with_chrome<'a>(body: Element<'a, Message>, maximized: bool) -> Element<'a, M
 }
 
 impl Oryxis {
+    /// Master-password field with Lucide eye toggle (matches host editor / identity forms).
+    fn vault_master_password_field<'a>(
+        &'a self,
+        placeholder: &'a str,
+        on_submit: Message,
+    ) -> Element<'a, Message> {
+        let field = text_input(placeholder, &self.vault_password_input)
+            .on_input(Message::VaultPasswordChanged)
+            .on_submit(on_submit)
+            .secure(!self.vault_password_visible)
+            .padding(12)
+            .width(Length::Fill)
+            .style(crate::widgets::rounded_input_style);
+        let toggle = button(
+            if self.vault_password_visible {
+                iced_fonts::lucide::eye_off().size(14).color(OryxisColors::t().text_muted)
+            } else {
+                iced_fonts::lucide::eye().size(14).color(OryxisColors::t().text_muted)
+            },
+        )
+        .on_press(Message::VaultTogglePasswordVisibility)
+        .style(|_t, _s| button::Style::default())
+        .padding(8);
+        container(
+            dir_row(vec![
+                field.into(),
+                Space::new().width(6).into(),
+                toggle.into(),
+            ])
+            .align_y(iced::Alignment::Center),
+        )
+        .width(300)
+        .into()
+    }
+
     pub(crate) fn view_vault_setup(&self) -> Element<'_, Message> {
         let logo = image(self.logo_handle.clone())
             .width(64)
@@ -41,13 +76,10 @@ impl Oryxis {
             .size(14)
             .color(OryxisColors::t().text_secondary);
 
-        let input = text_input(crate::i18n::t("master_password_optional"), &self.vault_password_input)
-            .on_input(Message::VaultPasswordChanged)
-            .on_submit(Message::VaultSetup)
-            .secure(true)
-            .padding(12)
-            .width(300)
-            .style(crate::widgets::rounded_input_style);
+        let input = self.vault_master_password_field(
+            crate::i18n::t("master_password_optional"),
+            Message::VaultSetup,
+        );
 
         let btn = styled_button(crate::i18n::t("create_vault"), Message::VaultSetup, OryxisColors::t().accent);
 
@@ -98,13 +130,10 @@ impl Oryxis {
             .size(14)
             .color(OryxisColors::t().text_secondary);
 
-        let input = text_input(crate::i18n::t("master_password_placeholder"), &self.vault_password_input)
-            .on_input(Message::VaultPasswordChanged)
-            .on_submit(Message::VaultUnlock)
-            .secure(true)
-            .padding(12)
-            .width(300)
-            .style(crate::widgets::rounded_input_style);
+        let input = self.vault_master_password_field(
+            crate::i18n::t("master_password_placeholder"),
+            Message::VaultUnlock,
+        );
 
         let btn = styled_button(crate::i18n::t("unlock"), Message::VaultUnlock, OryxisColors::t().accent);
 


### PR DESCRIPTION

[oryxis_1.webm](https://github.com/user-attachments/assets/c019d423-3d40-44d2-a303-eec956231fe9)

## What changed

| File | Change |
|------|--------|
| `crates/oryxis-app/src/app.rs` | `vault_password_visible: bool` on `Oryxis`. |
| `crates/oryxis-app/src/boot.rs` | Initialize `vault_password_visible` to `false`. |
| `crates/oryxis-app/src/messages.rs` | `Message::VaultTogglePasswordVisibility`. |
| `crates/oryxis-app/src/dispatch.rs` | Toggle handler; reset visibility to `false` when the vault password field is cleared after **unlock**, **setup**, or **vault reset**. |
| `crates/oryxis-app/src/views/vault.rs` | New `vault_master_password_field`: `text_input` + Lucide eye / eye-off in a `dir_row` (300px), `.secure(!vault_password_visible)`; **setup** and **unlock** screens call it instead of duplicating `text_input`. |

Same eye / eye-off pattern as the host editor and identity forms.

---

**Notice:** This pull request (code and description) was produced end-to-end with **AI assistance**. I have **reviewed** the diff and tested the behavior as far as I could, but I am **not a professional rust programmer** — please treat the changes with normal review scrutiny and flag anything that looks off.
