### PR TITLE
Add "release-with-split-debuginfo-packed" profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,7 @@ opt-level = 3
 lto = "thin"
 strip = true
 
+[profile.release-with-split-debuginfo-packed] 
+inherits = "release"
+debug = "true"
+split-debuginfo = "packed"


### PR DESCRIPTION
This PR adds a new profile for producing builds with split debuginfo files.

The profile is intended for opt-in use in specific builds, such as github actions/ci workflows for Windows to produce PDB files. It is intentionally explicitly named, rather than generically (such as `release-with-debug`) because:

  1) there is a matrix of split-debuginfo values and targets each with different effects
  2) this matrix of behaviour may not be stable, and may change in future rust versions
  3) target specific profiles (see commit message reference) would solve for this cleanly.
  4) there doesn't appear to be a way to say `split-debuginfo=default|true|yes`, allowing each rust target backend to do the right/best thing as they evolve. 
  5) given (4), to avoid inadvertently affecting (polluting) other targets' builds if named too generically.

Unfortunately I don't currently have a rust environment setup on this host to test PDB production with, but given the brevity of the change, and its likely initial use only for Windows nightly Oryxis CI builds rather than release builds for users, I think I can safely hand this over as is.
 
Next steps:

 - Use the new target initially for Windows nightly CI builds only (`.github/workflows/nightly.yml:build-windows-x86:`), to produce PDB's for pre-release testing and QA for Windows users.
 - Consider: Producing a debug symbols archive (zip) in a post-build step in Actions, so users can download them in the Assets section of the release.
 - Consider: Shipping PDB's in the Windows release builds. This may depend on their size, but they may also be optimizable using `debuginfo` [1])
 - Consider: In-app user-initiated mechanism to fetch the correct (versioned) PDB's from Github. This could be made be available in a `Main Menu -> Debug|Advanced -> Get Symbol Files` menu entry or similar.
 - If and when Oryxis adds a crash handler (for crash reporting), fetch symbols during crash processing.
 - Consider: Testing behaviour and value of split-debuginfo=packed on macOS and Linux nightly builds

[1] https://doc.rust-lang.org/rustc/codegen-options/index.html#debuginfo