### PR TITLE
Create and embed Windows manifest

### DIFF
--- a/crates/oryxis-app/build.rs
+++ b/crates/oryxis-app/build.rs
@@ -6,6 +6,7 @@ fn main() {
     #[cfg(windows)]
     {
         let mut res = winresource::WindowsResource::new();
+        res.set_manifest_file("../../resources/manifest.xml");
         res.set_icon("../../resources/logo.ico");
         res.set("FileDescription", "Oryxis SSH Client");
         res.set("ProductName", "Oryxis");

--- a/resources/manifest.xml
+++ b/resources/manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
This changeset adds a standalone `manifest.xml` file in `resources/`, containing the default tauri manifest content [1][2][3] and hooks it up in `oryxis-app/build.rs` so it's embedded as a resource in the final executable.

Without this, Oryxis fails to run in at least local Windows (11) builds and upstream nightly zip builds with error:

`The procedure entry point TaskDialogIndirect could not be located in the dynamic link library ... <path>/to/oryxis.exe`

I identified this during local builds testing for PDB production using new `profile.release-with-split-debuginfo-packed` target. I have not investigated why installers are seemingly not affected in the same way.

With these changes, a local rebuild and test execution of the resulting oryxis.exe executable successfully loads from the build target directory.

[1] https://docs.rs/tauri-build/latest/tauri_build/struct.WindowsAttributes.html#method.app_manifest`
[2] https://github.com/tauri-apps/tauri/issues/6732
[3] https://github.com/tauri-apps/tauri/issues/12247
