### PR TITLE
Enable PDB production for Windows nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -133,19 +133,24 @@ jobs:
             ~/.cargo/git/
             target/
           key: windows-x86-nightly-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo build --release -p oryxis-app
-      - name: Package zip
+      - run: cargo build --release-with-split-debuginfo-packed -p oryxis-app
+      - name: Package zip & pdb's
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist
-          Copy-Item target\release\oryxis.exe dist\
+          Copy-Item target\release-with-split-debuginfo-packed\oryxis.exe dist\
           Copy-Item README.md dist\
           Copy-Item resources\logo_64.png dist\
           Compress-Archive -Path dist\* -DestinationPath oryxis-nightly-windows-x86_64.zip
+          New-Item -ItemType Directory -Force -Path pdb
+          Copy-Item -Path target\release-with-split-debuginfo-packed\*.pdb pdb\
+          Compress-Archive -Path pdb\* -DestinationPath oryxis-nightly-windows-x86_64-pdb.zip
       - uses: actions/upload-artifact@v7
         with:
           name: oryxis-nightly-windows-x86_64
-          path: oryxis-nightly-windows-x86_64.zip
+          path: |
+            oryxis-nightly-windows-x86_64.zip
+            oryxis-nightly-windows-x86_64-pdb.zip
 
   build-windows-arm:
     name: Windows ARM64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -133,7 +133,7 @@ jobs:
             ~/.cargo/git/
             target/
           key: windows-x86-nightly-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo build --release-with-split-debuginfo-packed -p oryxis-app
+      - run: cargo build --profile release-with-split-debuginfo-packed -p oryxis-app
       - name: Package zip & pdb's
         shell: pwsh
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,5 +97,5 @@ strip = true
 
 [profile.release-with-split-debuginfo-packed] 
 inherits = "release"
-debug = true
+debug = "line-tables-only"
 split-debuginfo = "packed"


### PR DESCRIPTION
This change enables PDB production for Oryxis Windows nightly builds.

Each value of `debuginfo` (corresponding to `debug` [1] in profiles) was tested for output size comparison, with the following results:

Note: the CI workflow wont test this PR until merged to main. 

```
debug = true 
	oryxis.pdb: 390mb
	oryxis_cloud_aws_plugin.pdb: 139mb
	oryxis_mcp.pdb: 72mb
	oryxis_relay.pdb: 44mb

debug = "limited"
	oryxis.pdb: 142mb
	oryxis_cloud_aws_plugin.pdb: 59mb
	oryxis_mcp.pdb: 35mb
	oryxis_relay.pdb: 19mb

debug = "line-tables-only"
	oryxis.pdb: 142mb
	oryxis_cloud_aws_plugin.pdb: 59mb
	oryxis_mcp.pdb: 35mb
	oryxis_relay.pdb: 19mb
```

I'm not sure why `line-tables-only` returns identical debuginfo output as `limited`, but I anticipate this is either an upstream bug,  evidence of an evolution in debuginfo values and the information they contain as rust development continues, or potentially related to the LLVM version GitHub runners use.

I have tested this in [koobs/oryxis](https://github.com/koobs/oryxis) (see actions results) using the same workflows as upstream and confirmed:

 - Custom target only runs for nightly (only on pushes to main), not CI (for PR's)
 - Custom target only run for windows x64 (you may want to enable it for arm)
 - PDB's (a single oryxis.pdb in nightly release cases) are produced, packaged and uploaded as seperate artifact
 - Debug info is made available in Windows Performance Analyzer for ETL traces of Oryxis produced by Windows Performance Recorder.

Note: I used wildcarded `copy *.pdb \pdb` in the nightly workflow rather than explicit and static pdb filenames such that if at any time in the future Oryxis ships seperate dll's or executables (for example: plugins), all pdb's will be picked up and shipped together. That is to say, one zip artifact for oryxis (as now), and one zip for any/all pdb's produced.

[1] https://doc.rust-lang.org/cargo/reference/profiles.html#debug
[2] https://github.com/rust-lang/rust/pull/109808
[3] https://github.com/rust-lang/rust/issues/64405
[4] https://github.com/rust-lang/compiler-team/issues/613
[5] https://github.com/rust-lang/rust/issues?q=label%3A%22A-debuginfo%22