### PR TITLE
feat(sftp): keyboard navigation in the file browser

### DIFF
--- a/crates/oryxis-app/src/dispatch_sftp.rs
+++ b/crates/oryxis-app/src/dispatch_sftp.rs
@@ -350,7 +350,15 @@ impl Oryxis {
                 self.sftp.close_menus();
                 let client = match self.sftp.pane(side).client.clone() {
                     Some(c) => c,
-                    None => return Ok(Task::none()),
+                    None => {
+                        // No client to load from: drop any cursor target
+                        // queued for this side so a later successful load
+                        // doesn't consume a stale one.
+                        if matches!(&self.sftp.pending_focus, Some((s, _)) if *s == side) {
+                            self.sftp.pending_focus = None;
+                        }
+                        return Ok(Task::none());
+                    }
                 };
                 {
                     let pane = self.sftp.pane_mut(side);
@@ -373,11 +381,18 @@ impl Oryxis {
                 let entry_count = entries.len();
                 let path_for_log = path.clone();
                 let pane = self.sftp.pane_mut(side);
+                // Only a genuine directory change resets the scroll. A
+                // same-path reload (Refresh, post-op reload) keeps the
+                // scrollable's id, so iced preserves the visual scroll;
+                // zeroing list_scroll_y there would desync our tracked
+                // offset from the widget and break edge-based scrolling.
+                let changed_dir = pane.remote_path != path;
                 pane.remote_path = path;
                 pane.remote_entries = entries;
                 pane.remote_loading = false;
-                // New directory -> fresh scrollable starts at the top.
-                pane.list_scroll_y = 0.0;
+                if changed_dir {
+                    pane.list_scroll_y = 0.0;
+                }
                 // Selection is path-keyed; navigation invalidates it.
                 self.sftp.selected_rows.clear();
                 self.sftp.selection_anchor = None;
@@ -440,11 +455,16 @@ impl Oryxis {
             Message::SftpNavigateLocal(side, path) => {
                 {
                     let pane = self.sftp.pane_mut(side);
+                    // Only a real directory change resets the scroll (see
+                    // SftpRemoteLoaded): a same-path navigate keeps the
+                    // scrollable id and its preserved scroll position.
+                    let changed_dir = pane.local_path != path;
                     pane.local_path = path;
                     pane.drives_open = false;
                     pane.actions_open = false;
-                    // New directory -> fresh scrollable starts at the top.
-                    pane.list_scroll_y = 0.0;
+                    if changed_dir {
+                        pane.list_scroll_y = 0.0;
+                    }
                 }
                 self.sftp.left.actions_open = false;
                 self.sftp.right.actions_open = false;
@@ -1336,9 +1356,11 @@ impl Oryxis {
                 let Some(ch) = ch else {
                     return Err(Message::KeyboardEvent(ke));
                 };
-                // Type-ahead only kicks in once a row is selected (the
-                // selection's pane is the focus).
-                if self.sftp.selected_rows.last().is_none() {
+                // Type-ahead works from any keyboard cursor: a selected row
+                // (the selection's pane is the focus) or the ".." parent row
+                // (which clears selected_rows but sets parent_cursor on the
+                // focused pane).
+                if self.sftp.selected_rows.last().is_none() && !self.sftp.parent_cursor {
                     return Ok(Task::none());
                 }
                 let now = std::time::Instant::now();
@@ -1375,9 +1397,14 @@ impl Oryxis {
                 if generation != self.sftp.type_ahead_gen {
                     return Ok(Task::none());
                 }
-                let Some(side) = self.sftp.selected_rows.last().map(|(s, _)| *s) else {
-                    return Ok(Task::none());
-                };
+                // On the ".." row there's no selected row, so fall back to
+                // the focused pane (type-ahead works from the parent cursor).
+                let side = self
+                    .sftp
+                    .selected_rows
+                    .last()
+                    .map(|(s, _)| *s)
+                    .unwrap_or(self.sftp.focused_side);
                 let prefix = self.sftp.type_ahead.clone();
                 if prefix.is_empty() {
                     return Ok(Task::none());

--- a/crates/oryxis-app/src/dispatch_sftp.rs
+++ b/crates/oryxis-app/src/dispatch_sftp.rs
@@ -274,6 +274,10 @@ impl Oryxis {
                 );
             }
             Message::SftpRemoteError(side, msg) => {
+                // A failed navigation has no new listing to land the cursor on.
+                if matches!(&self.sftp.pending_focus, Some((s, _)) if *s == side) {
+                    self.sftp.pending_focus = None;
+                }
                 let had_listing = !self.sftp.pane(side).remote_entries.is_empty();
                 // Hard failure (nothing to fall back on) logs as an error;
                 // a soft failure that keeps the previous listing is a warning.
@@ -372,9 +376,12 @@ impl Oryxis {
                 pane.remote_path = path;
                 pane.remote_entries = entries;
                 pane.remote_loading = false;
+                // New directory -> fresh scrollable starts at the top.
+                pane.list_scroll_y = 0.0;
                 // Selection is path-keyed; navigation invalidates it.
                 self.sftp.selected_rows.clear();
                 self.sftp.selection_anchor = None;
+                self.sftp.parent_cursor = false;
                 self.push_sftp_log(
                     crate::state::SftpLogLevel::Info,
                     format!(
@@ -385,16 +392,49 @@ impl Oryxis {
                         crate::i18n::t("sftp_log_items"),
                     ),
                 );
+                // Folder descent / back-navigation: now the listing is in,
+                // drop the keyboard cursor where the move queued it.
+                if let Some(task) = self.sftp_take_pending_focus(side) {
+                    return Ok(task);
+                }
             }
             Message::SftpUp(side) => {
                 if self.sftp.pane(side).is_remote {
-                    let parent = parent_path(&self.sftp.pane(side).remote_path);
+                    let cur = self.sftp.pane(side).remote_path.clone();
+                    // Land the cursor on the folder we're leaving once the
+                    // parent loads (its full path in the parent listing).
+                    let child = cur.trim_end_matches('/').to_string();
+                    if !child.is_empty() {
+                        self.sftp.pending_focus =
+                            Some((side, crate::state::SftpPendingFocus::Path(child)));
+                    }
+                    let parent = parent_path(&cur);
                     return Ok(Task::done(Message::SftpNavigateRemote(side, parent)));
                 }
                 if let Some(p) = self.sftp.pane(side).local_path.parent() {
                     let p = p.to_path_buf();
-                    self.sftp.pane_mut(side).local_path = p;
+                    // The folder we're leaving, as it'll appear in the parent.
+                    let child = self
+                        .sftp
+                        .pane(side)
+                        .local_path
+                        .to_string_lossy()
+                        .into_owned();
+                    {
+                        let pane = self.sftp.pane_mut(side);
+                        pane.local_path = p;
+                        // New directory -> fresh scrollable starts at the top.
+                        pane.list_scroll_y = 0.0;
+                    }
+                    self.sftp.selected_rows.clear();
+                    self.sftp.selection_anchor = None;
+                    self.sftp.parent_cursor = false;
                     self.refresh_sftp_local(side);
+                    // Local listing is synchronous: focus the folder we left.
+                    return Ok(self.sftp_apply_pending_focus(
+                        side,
+                        crate::state::SftpPendingFocus::Path(child),
+                    ));
                 }
             }
             Message::SftpNavigateLocal(side, path) => {
@@ -403,12 +443,20 @@ impl Oryxis {
                     pane.local_path = path;
                     pane.drives_open = false;
                     pane.actions_open = false;
+                    // New directory -> fresh scrollable starts at the top.
+                    pane.list_scroll_y = 0.0;
                 }
                 self.sftp.left.actions_open = false;
                 self.sftp.right.actions_open = false;
                 self.sftp.selected_rows.clear();
                 self.sftp.selection_anchor = None;
+                self.sftp.parent_cursor = false;
                 self.refresh_sftp_local(side);
+                // Folder descent into a local folder: the (synchronous)
+                // listing is populated, so land the queued cursor now.
+                if let Some(task) = self.sftp_take_pending_focus(side) {
+                    return Ok(task);
+                }
             }
             Message::SftpRefreshLocal(side) => {
                 self.sftp.close_menus();
@@ -1115,6 +1163,10 @@ impl Oryxis {
                 });
             }
             Message::SftpSelectRow(side, path, is_dir) => {
+                // Keyboard focus follows the mouse: a clicked row's pane
+                // becomes the focused pane and the cursor leaves the ".." row.
+                self.sftp.focused_side = side;
+                self.sftp.parent_cursor = false;
                 let target = (side, path.clone());
                 let ctrl = self.modifiers.control() || self.modifiers.command();
                 let shift = self.modifiers.shift();
@@ -1197,6 +1249,11 @@ impl Oryxis {
                     tracing::info!("sftp op: {}", msg);
                 }
             }
+            Message::SftpListScrolled(side, offset_y, viewport_h) => {
+                let pane = self.sftp.pane_mut(side);
+                pane.list_scroll_y = offset_y;
+                pane.list_viewport_h = viewport_h;
+            }
             Message::KeyboardEvent(ke) => {
                 // Type-ahead: while a row is selected in the SFTP view,
                 // typing letters jumps the selection to the first entry whose
@@ -1215,6 +1272,51 @@ impl Oryxis {
                     || self.sftp.picker_open
                     || self.sftp.left.path_editing.is_some()
                     || self.sftp.right.path_editing.is_some();
+                // Arrow / Enter navigation: move the focused row or open
+                // it (folder -> navigate, file -> open). These are Named
+                // keys, so they never reach the type-ahead char extraction
+                // below; handle them here before that returns `Err` and
+                // forwards the keypress to the terminal/PTY. Suppressed
+                // while a modal/input owns the keyboard, and when a
+                // modifier is held (those belong to hotkeys / the PTY).
+                if !editing
+                    && let iced::keyboard::Event::KeyPressed {
+                        key: iced::keyboard::Key::Named(named),
+                        modifiers,
+                        ..
+                    } = &ke
+                    && !modifiers.control()
+                    && !modifiers.command()
+                    && !modifiers.alt()
+                {
+                    use iced::keyboard::key::Named;
+                    // Any of these takes the keyboard cursor over, so mute the
+                    // mouse-hover highlight until the mouse moves again.
+                    if matches!(
+                        named,
+                        Named::ArrowDown
+                            | Named::ArrowUp
+                            | Named::ArrowLeft
+                            | Named::ArrowRight
+                            | Named::Enter
+                            | Named::Tab
+                    ) {
+                        self.sftp.suppress_hover = true;
+                    }
+                    match named {
+                        Named::ArrowDown => return Ok(self.sftp_move_focus(true)),
+                        Named::ArrowUp => return Ok(self.sftp_move_focus(false)),
+                        // Right descends into a folder (or up via ".."); on a
+                        // file it does nothing. Enter additionally opens files.
+                        Named::ArrowRight => return Ok(self.sftp_activate_focused(false)),
+                        Named::Enter => return Ok(self.sftp_activate_focused(true)),
+                        // Left goes to the parent directory.
+                        Named::ArrowLeft => return Ok(self.sftp_focus_parent()),
+                        // Tab switches the focused pane.
+                        Named::Tab => return Ok(self.sftp_toggle_pane_focus()),
+                        _ => {}
+                    }
+                }
                 let ch = if editing {
                     None
                 } else if let iced::keyboard::Event::KeyPressed {
@@ -1254,6 +1356,8 @@ impl Oryxis {
                     self.sftp.type_ahead.push(lc);
                 }
                 self.sftp.type_ahead_at = Some(now);
+                // Type-ahead moves the keyboard cursor too; mute mouse hover.
+                self.sftp.suppress_hover = true;
                 // Debounce: bump the generation and search only after a short
                 // pause, so fast typing ("cla") resolves once with the full
                 // buffer instead of jumping on every key (c -> cl -> cla).
@@ -1348,6 +1452,8 @@ impl Oryxis {
                 let full = visible[idx].1.clone();
                 self.sftp.selected_rows = vec![(side, full.clone())];
                 self.sftp.selection_anchor = Some((side, full));
+                self.sftp.focused_side = side;
+                self.sftp.parent_cursor = false;
                 // Scroll the match into view via the pane's per-directory
                 // scroll id (must match the one the view builds).
                 let side_key = match side {

--- a/crates/oryxis-app/src/dispatch_tabs.rs
+++ b/crates/oryxis-app/src/dispatch_tabs.rs
@@ -110,6 +110,11 @@ impl Oryxis {
                     return Ok(Task::none());
                 }
                 self.mouse_position = if needs_drag_update { pos } else { snapped };
+                // A real mouse move restores the hover highlight that keyboard
+                // navigation muted (no-op when it wasn't suppressed).
+                if changed {
+                    self.sftp.suppress_hover = false;
+                }
                 // While the chat-sidebar resize handle is held down, the
                 // sidebar width tracks the cursor, dragging left grows
                 // the panel, dragging right shrinks it. Clamp to a sane

--- a/crates/oryxis-app/src/messages.rs
+++ b/crates/oryxis-app/src/messages.rs
@@ -218,6 +218,10 @@ pub enum Message {
     /// scheduled for; runs only if no newer keystroke superseded it
     /// (debounce, so fast typing searches once with the full buffer).
     SftpTypeAheadFire(u64),
+    /// A pane's file list scrolled: carries the side, the new absolute
+    /// vertical offset (px) and the visible viewport height (px). Stored so
+    /// keyboard navigation only scrolls when the cursor reaches an edge.
+    SftpListScrolled(crate::state::SftpPaneSide, f32, f32),
     SftpStartNewEntry(crate::state::SftpPaneSide, crate::state::SftpEntryKind),
     SftpNewEntryInput(String),
     SftpNewEntryCommit,

--- a/crates/oryxis-app/src/sftp_methods.rs
+++ b/crates/oryxis-app/src/sftp_methods.rs
@@ -180,6 +180,314 @@ impl Oryxis {
         }
     }
 
+    /// Whether the given pane shows a `..` (parent) row, matching the view's
+    /// own condition: any local path with a parent, or any remote path that
+    /// isn't the root. The `..` row is a virtual first entry the keyboard
+    /// cursor can land on (Enter / Right / Left there navigate up).
+    pub(crate) fn sftp_pane_has_parent(&self, side: crate::state::SftpPaneSide) -> bool {
+        let pane = self.sftp.pane(side);
+        if pane.is_remote {
+            pane.remote_path != "/" && !pane.remote_path.is_empty()
+        } else {
+            pane.local_path.parent().is_some()
+        }
+    }
+
+    /// The per-directory scrollable id for a pane's file list. Must match
+    /// the id the view builds so scroll operations target the right widget.
+    fn sftp_list_scroll_id(&self, side: crate::state::SftpPaneSide) -> String {
+        let pane = self.sftp.pane(side);
+        let cur_path = if pane.is_remote {
+            pane.remote_path.clone()
+        } else {
+            pane.local_path.to_string_lossy().into_owned()
+        };
+        let side_key = match side {
+            crate::state::SftpPaneSide::Left => "left",
+            crate::state::SftpPaneSide::Right => "right",
+        };
+        format!("sftp-list-{side_key}-{cur_path}")
+    }
+
+    /// Snap a pane's list to a relative vertical position (0.0 top .. 1.0
+    /// bottom). Fallback used when the viewport height isn't known yet.
+    fn sftp_snap_ratio(
+        &self,
+        side: crate::state::SftpPaneSide,
+        idx: usize,
+        total: usize,
+    ) -> Task<Message> {
+        let ratio = if total > 1 {
+            idx as f32 / (total - 1) as f32
+        } else {
+            0.0
+        };
+        iced::widget::operation::snap_to(
+            iced::widget::Id::from(self.sftp_list_scroll_id(side)),
+            iced::widget::scrollable::RelativeOffset {
+                x: None,
+                y: Some(ratio),
+            },
+        )
+    }
+
+    /// Bring the row at `idx` (of `total`, `..` included) into view, but
+    /// only scroll when it would otherwise sit outside the viewport: above
+    /// the top edge (scroll up so it's the first visible row) or below the
+    /// bottom edge (scroll down so it's the last). A row already fully
+    /// visible doesn't move the list. Falls back to proportional snapping
+    /// until the first `on_scroll` reports the viewport height.
+    fn sftp_scroll_row_into_view(
+        &mut self,
+        side: crate::state::SftpPaneSide,
+        idx: usize,
+        total: usize,
+    ) -> Task<Message> {
+        use crate::views::sftp::ROW_HEIGHT;
+        let viewport_h = self.sftp.pane(side).list_viewport_h;
+        if viewport_h <= 0.0 {
+            return self.sftp_snap_ratio(side, idx, total);
+        }
+        let content_h = total as f32 * ROW_HEIGHT;
+        let max_scroll = (content_h - viewport_h).max(0.0);
+        if max_scroll <= 0.0 {
+            // Whole list fits; nothing to scroll.
+            return Task::none();
+        }
+        let offset = self.sftp.pane(side).list_scroll_y.clamp(0.0, max_scroll);
+        let row_top = idx as f32 * ROW_HEIGHT;
+        let row_bottom = row_top + ROW_HEIGHT;
+        let new_offset = if row_top < offset {
+            row_top
+        } else if row_bottom > offset + viewport_h {
+            row_bottom - viewport_h
+        } else {
+            // Already fully visible: leave the scroll position untouched.
+            return Task::none();
+        };
+        let new_offset = new_offset.clamp(0.0, max_scroll);
+        // Optimistically record the offset so a burst of key presses before
+        // the next `on_scroll` arrives still computes against fresh state.
+        self.sftp.pane_mut(side).list_scroll_y = new_offset;
+        iced::widget::operation::snap_to(
+            iced::widget::Id::from(self.sftp_list_scroll_id(side)),
+            iced::widget::scrollable::RelativeOffset {
+                x: None,
+                y: Some(new_offset / max_scroll),
+            },
+        )
+    }
+
+    /// Park the keyboard cursor on the focused pane's `..` row: clear the
+    /// real-row selection and flag `parent_cursor`. Pins the list to the
+    /// top unconditionally (not the edge-based "only if off-screen" path)
+    /// so `..` is always visible even when iced restored a previous scroll
+    /// position for this directory's scrollable id.
+    fn sftp_focus_parent_row(
+        &mut self,
+        side: crate::state::SftpPaneSide,
+        total: usize,
+    ) -> Task<Message> {
+        self.sftp.parent_cursor = true;
+        self.sftp.selected_rows.clear();
+        self.sftp.selection_anchor = None;
+        self.sftp.pane_mut(side).list_scroll_y = 0.0;
+        self.sftp_snap_ratio(side, 0, total)
+    }
+
+    /// Move the keyboard cursor one row up (`down == false`) or down within
+    /// the focused pane, replacing any multi-row selection with the single
+    /// new row and scrolling it into view. The `..` parent row, when shown,
+    /// is the virtual first entry, so moving up from the first real row
+    /// lands on it. With no current cursor, the first (down) or last (up)
+    /// row is selected.
+    pub(crate) fn sftp_move_focus(&mut self, down: bool) -> Task<Message> {
+        let side = self.sftp.focused_side;
+        let entries = self.visible_entry_paths_in_pane(side);
+        let has_parent = self.sftp_pane_has_parent(side);
+        let offset = usize::from(has_parent);
+        let total = entries.len() + offset;
+        if total == 0 {
+            return Task::none();
+        }
+        // Virtual index over [".." , entries...]; ".." is index 0 when shown.
+        let cur_virtual = if self.sftp.parent_cursor && has_parent {
+            Some(0)
+        } else {
+            self.sftp
+                .selected_rows
+                .last()
+                .filter(|(s, _)| *s == side)
+                .and_then(|(_, p)| entries.iter().position(|e| e == p))
+                .map(|i| i + offset)
+        };
+        let new_v = match cur_virtual {
+            Some(i) if down => (i + 1).min(total - 1),
+            Some(i) => i.saturating_sub(1),
+            None if down => 0,
+            None => total - 1,
+        };
+        if has_parent && new_v == 0 {
+            return self.sftp_focus_parent_row(side, total);
+        }
+        self.sftp.parent_cursor = false;
+        let full = entries[new_v - offset].clone();
+        self.sftp.selected_rows = vec![(side, full.clone())];
+        self.sftp.selection_anchor = Some((side, full));
+        self.sftp_scroll_row_into_view(side, new_v, total)
+    }
+
+    /// If a pending cursor target is queued for `side`, consume it and
+    /// return the task that lands the cursor. Called from the directory-load
+    /// handlers once the new listing is in.
+    pub(crate) fn sftp_take_pending_focus(
+        &mut self,
+        side: crate::state::SftpPaneSide,
+    ) -> Option<Task<Message>> {
+        match self.sftp.pending_focus.clone() {
+            Some((s, target)) if s == side => {
+                self.sftp.pending_focus = None;
+                Some(self.sftp_apply_pending_focus(side, target))
+            }
+            _ => None,
+        }
+    }
+
+    /// Land the keyboard cursor on a freshly loaded directory according to
+    /// `target`: the first entry, the `..` row, or a specific path (with
+    /// graceful fallback to the first entry / `..` when it isn't shown).
+    pub(crate) fn sftp_apply_pending_focus(
+        &mut self,
+        side: crate::state::SftpPaneSide,
+        target: crate::state::SftpPendingFocus,
+    ) -> Task<Message> {
+        use crate::state::SftpPendingFocus;
+        self.sftp.focused_side = side;
+        let entries = self.visible_entry_paths_in_pane(side);
+        let has_parent = self.sftp_pane_has_parent(side);
+        let offset = usize::from(has_parent);
+        let total = entries.len() + offset;
+        // Resolve the index into `entries`, or None to fall back to "..".
+        let entry_idx: Option<usize> = match target {
+            SftpPendingFocus::Parent => None,
+            SftpPendingFocus::Path(p) => entries
+                .iter()
+                .position(|e| *e == p)
+                .or_else(|| (!entries.is_empty()).then_some(0)),
+        };
+        if let Some(i) = entry_idx {
+            self.sftp.parent_cursor = false;
+            let full = entries[i].clone();
+            self.sftp.selected_rows = vec![(side, full.clone())];
+            self.sftp.selection_anchor = Some((side, full));
+            self.sftp_scroll_row_into_view(side, i + offset, total)
+        } else if has_parent {
+            self.sftp_focus_parent_row(side, total)
+        } else {
+            self.sftp.selected_rows.clear();
+            self.sftp.selection_anchor = None;
+            self.sftp.parent_cursor = false;
+            Task::none()
+        }
+    }
+
+    /// Activate the focused row. Both Enter (`open_files == true`) and Right
+    /// (`false`) descend into a folder and land the keyboard cursor on the
+    /// opened folder's `..` row. Enter additionally opens a *file* (local via
+    /// the OS handler, remote via edit-in-place); Right does nothing on a
+    /// file. The `..` cursor navigates to the parent either way. No-op when
+    /// nothing is focused.
+    pub(crate) fn sftp_activate_focused(&mut self, open_files: bool) -> Task<Message> {
+        use crate::state::SftpPendingFocus;
+        let side = self.sftp.focused_side;
+        if self.sftp.parent_cursor {
+            return Task::done(Message::SftpUp(side));
+        }
+        let Some((side, path)) = self
+            .sftp
+            .selected_rows
+            .last()
+            .filter(|(s, _)| *s == side)
+            .cloned()
+        else {
+            return Task::none();
+        };
+        let is_dir = self.row_is_dir_in_pane(side, &path);
+        let is_remote = self.sftp.pane(side).is_remote;
+        if is_dir {
+            self.sftp.selected_rows.clear();
+            self.sftp.selection_anchor = None;
+            self.sftp.parent_cursor = false;
+            // Descend and keep the cursor on the new folder's ".." row once
+            // its listing loads (same for Enter and Right).
+            self.sftp.pending_focus = Some((side, SftpPendingFocus::Parent));
+            if is_remote {
+                Task::done(Message::SftpNavigateRemote(side, path))
+            } else {
+                Task::done(Message::SftpNavigateLocal(
+                    side,
+                    std::path::PathBuf::from(path),
+                ))
+            }
+        } else if !open_files {
+            // Right arrow on a file: nothing to descend into.
+            Task::none()
+        } else if is_remote {
+            Task::done(Message::SftpStartEdit(path))
+        } else {
+            Task::done(Message::SftpOpenLocal(std::path::PathBuf::from(path)))
+        }
+    }
+
+    /// Move keyboard focus to the parent directory of the focused pane
+    /// (Left arrow). Just dispatches the existing up-navigation.
+    pub(crate) fn sftp_focus_parent(&mut self) -> Task<Message> {
+        Task::done(Message::SftpUp(self.sftp.focused_side))
+    }
+
+    /// Toggle keyboard focus between the two panes (Tab). Lands the cursor
+    /// on a row in the newly focused pane: a prior selection there if it's
+    /// still visible, else its first row, else the `..` row.
+    pub(crate) fn sftp_toggle_pane_focus(&mut self) -> Task<Message> {
+        use crate::state::SftpPaneSide::{Left, Right};
+        let new_side = match self.sftp.focused_side {
+            Left => Right,
+            Right => Left,
+        };
+        self.sftp.focused_side = new_side;
+        self.sftp.parent_cursor = false;
+        self.sftp.selection_anchor = None;
+        let entries = self.visible_entry_paths_in_pane(new_side);
+        let has_parent = self.sftp_pane_has_parent(new_side);
+        let offset = usize::from(has_parent);
+        let total = entries.len() + offset;
+        // Preserve a prior selection in the target pane if it's still shown.
+        let prior = self
+            .sftp
+            .selected_rows
+            .iter()
+            .find(|(s, _)| *s == new_side)
+            .map(|(_, p)| p.clone())
+            .filter(|p| entries.iter().any(|e| e == p));
+        if let Some(p) = prior {
+            let idx = entries.iter().position(|e| e == &p).unwrap_or(0);
+            self.sftp.selected_rows = vec![(new_side, p.clone())];
+            self.sftp.selection_anchor = Some((new_side, p));
+            return self.sftp_scroll_row_into_view(new_side, idx + offset, total);
+        }
+        if let Some(first) = entries.first().cloned() {
+            self.sftp.selected_rows = vec![(new_side, first.clone())];
+            self.sftp.selection_anchor = Some((new_side, first));
+            return self.sftp_scroll_row_into_view(new_side, offset, total);
+        }
+        // Empty pane: park on ".." when present, otherwise just clear.
+        self.sftp.selected_rows.clear();
+        if has_parent {
+            return self.sftp_focus_parent_row(new_side, total);
+        }
+        Task::none()
+    }
+
     /// Rough hit-test for "is the cursor inside the remote pane?". Used
     /// at file-drop time to decide whether the OS drop targets the remote
     /// upload path. The panes split the content area 50/50 so we just

--- a/crates/oryxis-app/src/state/sftp.rs
+++ b/crates/oryxis-app/src/state/sftp.rs
@@ -199,7 +199,7 @@ pub(crate) struct SftpState {
 pub(crate) enum SftpPendingFocus {
     /// The `..` parent row (Enter / Right descent into a folder).
     Parent,
-    /// The entry with this full path, if still present — used by back-
+    /// The entry with this full path, if still present, used by back-
     /// navigation to land on the folder we just came out of. Falls back to
     /// the first entry, then `..`, when the path isn't in the new listing.
     Path(String),

--- a/crates/oryxis-app/src/state/sftp.rs
+++ b/crates/oryxis-app/src/state/sftp.rs
@@ -52,6 +52,14 @@ pub(crate) struct PaneState {
     /// True while this pane's collapsed filter input (narrow layout) is
     /// expanded into its floating popover.
     pub filter_open: bool,
+    /// Last known absolute vertical scroll offset (px) of this pane's file
+    /// list, fed from the scrollable's `on_scroll`. Used by keyboard
+    /// navigation to scroll only when the cursor reaches a viewport edge.
+    pub list_scroll_y: f32,
+    /// Last known visible height (px) of this pane's file list viewport,
+    /// also from `on_scroll`. `0.0` until the first scroll event (then the
+    /// nav falls back to proportional snapping).
+    pub list_viewport_h: f32,
 }
 
 /// State for the SFTP browser. Two panes, side-by-side: the left pane is
@@ -166,6 +174,35 @@ pub(crate) struct SftpState {
     pub log: Vec<SftpLogEntry>,
     /// Whether the message-log panel at the bottom of the view is open.
     pub log_open: bool,
+    /// Which pane currently holds keyboard focus for arrow / Enter / Tab
+    /// navigation. Tab toggles it; a mouse click on a row follows it.
+    /// Distinct from `selected_rows` so focus survives an empty pane (Tab
+    /// can land on a pane with nothing selected yet).
+    pub focused_side: SftpPaneSide,
+    /// True when the keyboard cursor sits on the `..` (parent) row of the
+    /// focused pane rather than on a real entry. Mutually exclusive with a
+    /// selected row in that pane: setting it clears `selected_rows`.
+    pub parent_cursor: bool,
+    /// Suppress the mouse-hover row highlight after a keyboard navigation
+    /// key, so the hover under a stationary cursor doesn't fight the
+    /// keyboard cursor. Cleared on the next real mouse move.
+    pub suppress_hover: bool,
+    /// Where to drop the keyboard cursor once a pane's *next* directory
+    /// listing loads. Set by folder descent (Right / Enter) and back-
+    /// navigation so the cursor follows the move; consumed by the load
+    /// handler (remote loads are async, so it can't be applied inline).
+    pub pending_focus: Option<(SftpPaneSide, SftpPendingFocus)>,
+}
+
+/// The keyboard cursor target to apply after a directory listing loads.
+#[derive(Debug, Clone)]
+pub(crate) enum SftpPendingFocus {
+    /// The `..` parent row (Enter / Right descent into a folder).
+    Parent,
+    /// The entry with this full path, if still present — used by back-
+    /// navigation to land on the folder we just came out of. Falls back to
+    /// the first entry, then `..`, when the path isn't in the new listing.
+    Path(String),
 }
 
 /// Cap on retained SFTP log lines per tab; older lines are dropped.
@@ -216,6 +253,10 @@ impl Default for SftpState {
             transfer_bytes_total: 0,
             log: Vec::new(),
             log_open: false,
+            focused_side: SftpPaneSide::Left,
+            parent_cursor: false,
+            suppress_hover: false,
+            pending_focus: None,
         }
     }
 }

--- a/crates/oryxis-app/src/views/sftp.rs
+++ b/crates/oryxis-app/src/views/sftp.rs
@@ -11,7 +11,7 @@ use crate::state::{SftpEntryKind, SftpPaneSide};
 use crate::theme::OryxisColors;
 use crate::widgets::dir_align_x;
 
-const ROW_HEIGHT: f32 = 28.0;
+pub(crate) const ROW_HEIGHT: f32 = 28.0;
 
 /// Which pane-anchored popover is open (layered at the view level so its
 /// dismiss scrim covers the whole view).
@@ -537,7 +537,16 @@ impl Oryxis {
             } else {
                 let mut col = column![].spacing(0);
                 if pane.local_path.parent().is_some() {
-                    col = col.push(parent_row(side, &ordered_cols, col_widths, layout));
+                    let parent_selected =
+                        self.sftp.parent_cursor && self.sftp.focused_side == side;
+                    col = col.push(parent_row(
+                        side,
+                        parent_selected,
+                        self.sftp.suppress_hover,
+                        &ordered_cols,
+                        col_widths,
+                        layout,
+                    ));
                 }
                 // Per-pane invariants hoisted out of the entry loop:
                 // rename state for this side, the selected-row paths as
@@ -591,6 +600,7 @@ impl Oryxis {
                         rename_input,
                         is_selected,
                         is_drop_target,
+                        self.sftp.suppress_hover,
                         &ordered_cols,
                         col_widths,
                         layout,
@@ -692,7 +702,16 @@ impl Oryxis {
         } else {
             let mut col = column![].spacing(0);
             if pane.remote_path != "/" && !pane.remote_path.is_empty() {
-                col = col.push(parent_row(side, &ordered_cols, col_widths, layout));
+                let parent_selected =
+                    self.sftp.parent_cursor && self.sftp.focused_side == side;
+                col = col.push(parent_row(
+                    side,
+                    parent_selected,
+                    self.sftp.suppress_hover,
+                    &ordered_cols,
+                    col_widths,
+                    layout,
+                ));
             }
             // Same per-pane invariants as the local branch, hoisted out
             // of the entry loop: rename state, the selected paths as a
@@ -749,6 +768,7 @@ impl Oryxis {
                     rename_input,
                     is_drop_target,
                     is_selected,
+                    self.sftp.suppress_hover,
                     &ordered_cols,
                     col_widths,
                     layout,
@@ -1915,6 +1935,8 @@ fn local_crumb<'a>(side: SftpPaneSide, label: String, full: std::path::PathBuf) 
 
 fn parent_row<'a>(
     side: SftpPaneSide,
+    selected: bool,
+    suppress_hover: bool,
     visible: &[crate::state::SftpColumn],
     widths: crate::state::SftpColWidths,
     layout: ColLayout,
@@ -1940,10 +1962,15 @@ fn parent_row<'a>(
         .width(layout.row_len)
         .height(Length::Fixed(ROW_HEIGHT))
         .on_press(msg)
-        .style(|_, status| {
-            let bg = match status {
-                BtnStatus::Hovered => OryxisColors::t().bg_hover,
-                _ => Color::TRANSPARENT,
+        .style(move |_, status| {
+            // Keyboard cursor highlight mirrors a selected file row.
+            let bg = if selected {
+                Color { a: 0.20, ..OryxisColors::t().accent }
+            } else {
+                match status {
+                    BtnStatus::Hovered if !suppress_hover => OryxisColors::t().bg_hover,
+                    _ => Color::TRANSPARENT,
+                }
             };
             button::Style {
                 background: Some(Background::Color(bg)),
@@ -2169,6 +2196,11 @@ fn sftp_list_scrollable<'a>(
     drag_col: Option<crate::state::SftpColumn>,
     hovered: Option<crate::state::SftpColumn>,
 ) -> Element<'a, Message> {
+    // Report scroll position + viewport height so keyboard navigation can
+    // scroll only when the cursor reaches a viewport edge (not on every step).
+    let on_scroll = move |vp: scrollable::Viewport| {
+        Message::SftpListScrolled(side, vp.absolute_offset().y, vp.bounds().height)
+    };
     if layout.overflow {
         // Sticky header + horizontal scroll (FileZilla-style): the rows get
         // their own vertical scrollable, and that plus the header sit inside
@@ -2178,7 +2210,8 @@ fn sftp_list_scrollable<'a>(
         let inner_list = scrollable(col)
             .id(iced::widget::Id::from(scroll_id.to_string()))
             .width(layout.row_len)
-            .height(Length::Fill);
+            .height(Length::Fill)
+            .on_scroll(on_scroll);
         let header = column_headers(side, sort, visible, widths, layout, drag_col, hovered);
         let stacked = column![header, inner_list]
             .width(layout.row_len)
@@ -2193,6 +2226,7 @@ fn sftp_list_scrollable<'a>(
             .id(iced::widget::Id::from(scroll_id.to_string()))
             .width(Length::Fill)
             .height(Length::Fill)
+            .on_scroll(on_scroll)
             .into()
     }
 }
@@ -2427,6 +2461,7 @@ fn file_row_local<'a>(
     rename_input: Option<&str>,
     is_selected: bool,
     is_drop_target: bool,
+    suppress_hover: bool,
     visible: &[crate::state::SftpColumn],
     widths: crate::state::SftpColWidths,
     layout: ColLayout,
@@ -2493,7 +2528,10 @@ fn file_row_local<'a>(
                 Color { a: 0.20, ..OryxisColors::t().accent }
             } else {
                 match status {
-                    BtnStatus::Hovered => OryxisColors::t().bg_hover,
+                    // Keyboard nav suppresses the mouse-hover tint until the
+                    // cursor moves again, so it doesn't compete with the
+                    // keyboard cursor on a stationary mouse.
+                    BtnStatus::Hovered if !suppress_hover => OryxisColors::t().bg_hover,
                     _ => Color::TRANSPARENT,
                 }
             };
@@ -2531,6 +2569,7 @@ fn file_row_remote<'a>(
     rename_input: Option<&str>,
     is_drop_target: bool,
     is_selected: bool,
+    suppress_hover: bool,
     visible: &[crate::state::SftpColumn],
     widths: crate::state::SftpColWidths,
     layout: ColLayout,
@@ -2594,7 +2633,9 @@ fn file_row_remote<'a>(
                 Color { a: 0.20, ..OryxisColors::t().accent }
             } else {
                 match status {
-                    BtnStatus::Hovered => OryxisColors::t().bg_hover,
+                    // See file_row_local: keyboard nav mutes hover until the
+                    // mouse moves.
+                    BtnStatus::Hovered if !suppress_hover => OryxisColors::t().bg_hover,
                     _ => Color::TRANSPARENT,
                 }
             };


### PR DESCRIPTION
Adds arrow / Enter / Tab keyboard navigation to the SFTP dual-pane browser, which previously supported only type-ahead search and mouse interaction.

## Behavior
- **Up / Down** move a keyboard cursor between rows; the `..` parent row is a virtual first entry the cursor can land on.
- **Enter** and **Right** descend into a folder and land the cursor on the new folder's `..` row (view pinned to the top). Enter additionally opens a file (local via the OS handler, remote via edit-in-place); Right does nothing on a file.
- **Left**, and Enter/Right on `..`, navigate to the parent and land the cursor on the folder just left.
- **Tab** switches the focused pane.
- The list scrolls **only when the cursor reaches a viewport edge** (tracked via the scrollable's `on_scroll`), not on every step.
- The mouse-hover row highlight is muted after a key press until the mouse moves again.

## Implementation notes
- New `focused_side` / `parent_cursor` / `suppress_hover` / `pending_focus` state on `SftpState`; new `list_scroll_y` / `list_viewport_h` per pane.
- Keyboard handling lives in `dispatch_sftp.rs` `KeyboardEvent` (named keys handled before the existing type-ahead char path, so they no longer leak to the terminal/PTY).
- Navigation helpers in `sftp_methods.rs`; row builders in `views/sftp.rs` gained a `suppress_hover` flag and the `..` row a selected highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)