### PR TITLE
Fix terminal drag-and-drop not working when Dashboard view is active

### DIFF
--- a/crates/oryxis-app/src/dispatch_terminal/drop.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/drop.rs
@@ -85,11 +85,13 @@ impl Oryxis {
         // other view) on screen there is no pane under the cursor, and
         // uploading into a BACKGROUND tab is the #106 behavior this
         // replaces. The SFTP surfaces already claimed their drops
-        // upstream. Terminal content is on screen when the active view
-        // is Terminal, or when the Dashboard shows a focused session tab.
+        // upstream. "Visible" mirrors `view_content`: a focused session
+        // tab renders the terminal under ANY view tag (closing a chip,
+        // Close Others or Reconnect focus a tab without touching
+        // `active_view`), so the gate is the same expression the
+        // keyboard / mouse / palette routers use, not a per-view check.
         let terminal_on_screen = self.active_view == crate::state::View::Terminal
-            || (self.active_tab.is_some()
-                && self.active_view == crate::state::View::Dashboard);
+            || self.active_tab.is_some();
         if !terminal_on_screen {
             return Task::none();
         }

--- a/crates/oryxis-app/src/dispatch_terminal/drop.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/drop.rs
@@ -85,8 +85,12 @@ impl Oryxis {
         // other view) on screen there is no pane under the cursor, and
         // uploading into a BACKGROUND tab is the #106 behavior this
         // replaces. The SFTP surfaces already claimed their drops
-        // upstream.
-        if self.active_view != crate::state::View::Terminal {
+        // upstream. Terminal content is on screen when the active view
+        // is Terminal, or when the Dashboard shows a focused session tab.
+        let terminal_on_screen = self.active_view == crate::state::View::Terminal
+            || (self.active_tab.is_some()
+                && self.active_view == crate::state::View::Dashboard);
+        if !terminal_on_screen {
             return Task::none();
         }
         let Some(tab_idx) = self.active_tab else {


### PR DESCRIPTION
When a terminal session tab is focused from the Dashboard (Home) view, active_view remains as Dashboard instead of switching to Terminal. The handle_terminal_drop_flush handler only allowed file drops when active_view == Terminal, causing all drag-and-drop uploads (ZMODEM, SFTP) to be silently discarded.

This fix aligns the drop handler with the existing in-terminal pattern already used elsewhere in the codebase (shortcuts/keyboard.rs, shortcuts/mouse.rs, palette.rs): terminal content is considered on screen when active_view == Terminal OR when a session tab is focused under the Dashboard view.