### PR TITLE
Align tab UX with Termius conventions

### DIFF
--- a/crates/oryxis-app/src/dispatch_navigation.rs
+++ b/crates/oryxis-app/src/dispatch_navigation.rs
@@ -37,6 +37,16 @@ impl Oryxis {
                 return self.panel_nav_tab_resolved(forward, focused);
             }
             // -- Navigation --
+            NavigationMessage::GoHome => {
+                if let Some(gid) = self.active_group {
+                    return Task::done(Message::Navigation(
+                        NavigationMessage::OpenGroup(gid),
+                    ));
+                }
+                return Task::done(Message::Navigation(
+                    NavigationMessage::ChangeView(View::Dashboard),
+                ));
+            }
             NavigationMessage::ChangeView(view) => {
                 // Navigating away from the Shortcuts editor cancels
                 // any pending capture so the next keystroke doesn't
@@ -190,7 +200,13 @@ impl Oryxis {
             }
             NavigationMessage::OpenGroup(gid) => {
                 self.active_group = Some(gid);
+                self.active_view = View::Dashboard;
+                self.active_tab = None;
                 self.host_search.clear();
+                // Dismiss any open overlay that belongs to the previous
+                // surface (burger menu, kebab, etc.), same as ChangeView.
+                self.panels.burger_menu = false;
+                self.overlay = None;
                 // Auto-trigger resolve when the user opens a dynamic
                 // group, saves an extra click. Re-resolve when there's
                 // no cache yet, or when the cached list has gone stale

--- a/crates/oryxis-app/src/dispatch_navigation.rs
+++ b/crates/oryxis-app/src/dispatch_navigation.rs
@@ -38,14 +38,24 @@ impl Oryxis {
             }
             // -- Navigation --
             NavigationMessage::GoHome => {
-                if let Some(gid) = self.active_group {
-                    return Task::done(Message::Navigation(
-                        NavigationMessage::OpenGroup(gid),
-                    ));
-                }
-                return Task::done(Message::Navigation(
+                // The Home tab lands on the vault surface the user left,
+                // folder included. It goes THROUGH `ChangeView` rather
+                // than setting `active_view` itself: leaving a view runs
+                // a pile of teardown (Monitoring's idle TTL, the keynav
+                // item lists, open overlays, the Shortcuts capture) that
+                // a second copy here would drift from silently. Then
+                // re-open the group `ChangeView` just reset to root.
+                let group = self.active_group;
+                let leave = self.handle_navigation(
                     NavigationMessage::ChangeView(View::Dashboard),
-                ));
+                );
+                let Some(gid) = group else {
+                    return leave;
+                };
+                let enter = self.handle_navigation(
+                    NavigationMessage::OpenGroup(gid),
+                );
+                return Task::batch([leave, enter]);
             }
             NavigationMessage::ChangeView(view) => {
                 // Navigating away from the Shortcuts editor cancels
@@ -103,8 +113,11 @@ impl Oryxis {
                 self.keynav.subnav_items.borrow_mut().clear();
                 self.keynav_clear_content();
                 self.keynav.settings_row_actions.borrow_mut().clear();
-                // Navigating to the host list (Home tab / Hosts pill)
-                // returns to the root, not whichever group was last open.
+                // Navigating to the host list (Hosts pill, its burger
+                // entry, Ctrl+Shift+1) returns to the root, not whichever
+                // group was last open, and stays the one-click way back
+                // out of a nested folder. The Home tab is the opposite
+                // door: `GoHome` re-opens the folder right after this.
                 if view == View::Dashboard {
                     self.active_group = None;
                 }
@@ -200,13 +213,7 @@ impl Oryxis {
             }
             NavigationMessage::OpenGroup(gid) => {
                 self.active_group = Some(gid);
-                self.active_view = View::Dashboard;
-                self.active_tab = None;
                 self.host_search.clear();
-                // Dismiss any open overlay that belongs to the previous
-                // surface (burger menu, kebab, etc.), same as ChangeView.
-                self.panels.burger_menu = false;
-                self.overlay = None;
                 // Auto-trigger resolve when the user opens a dynamic
                 // group, saves an extra click. Re-resolve when there's
                 // no cache yet, or when the cached list has gone stale

--- a/crates/oryxis-app/src/messages/navigation.rs
+++ b/crates/oryxis-app/src/messages/navigation.rs
@@ -6,6 +6,10 @@ use crate::state::{View};
 #[derive(Debug, Clone)]
 pub enum NavigationMessage {
     ChangeView(View),
+    /// Clicked the Home button or the burger-menu Hosts entry.
+    /// Resolves to OpenGroup when inside a folder, ChangeView(Dashboard)
+    /// at root — decided at click time, not render time.
+    GoHome,
     QuickHostInput(String),
     QuickHostContinue,
     OpenGroup(Uuid),

--- a/crates/oryxis-app/src/messages/navigation.rs
+++ b/crates/oryxis-app/src/messages/navigation.rs
@@ -6,9 +6,11 @@ use crate::state::{View};
 #[derive(Debug, Clone)]
 pub enum NavigationMessage {
     ChangeView(View),
-    /// Clicked the Home button or the burger-menu Hosts entry.
-    /// Resolves to OpenGroup when inside a folder, ChangeView(Dashboard)
-    /// at root — decided at click time, not render time.
+    /// The Home tab (its house chip and the strip slot behind it).
+    /// Leaves the current view like any `ChangeView(Dashboard)`, then
+    /// re-opens the group the user was standing in, so Home comes back
+    /// to the folder instead of the root. Resolved at click time, not
+    /// render time, because the folder is only known then.
     GoHome,
     QuickHostInput(String),
     QuickHostContinue,

--- a/crates/oryxis-app/src/shortcuts/targets.rs
+++ b/crates/oryxis-app/src/shortcuts/targets.rs
@@ -29,7 +29,9 @@ impl Oryxis {
         // Home stays reachable on Ctrl+Shift+1 (the vault section slot)
         // and on its house icon.
         if self.prefs.tab_slot_includes_home {
-            slots.push(Message::Navigation(NavigationMessage::ChangeView(View::Dashboard)));
+            // `GoHome`, not `ChangeView`: this slot IS the house chip, so
+            // the key has to keep the folder the click keeps.
+            slots.push(Message::Navigation(NavigationMessage::GoHome));
         }
         slots.extend(self.ordered_tab_refs().iter().filter_map(|r| self.tab_ref_select_msg(r)));
         slots.into_iter().nth(slot)

--- a/crates/oryxis-app/src/views/layout/menus.rs
+++ b/crates/oryxis-app/src/views/layout/menus.rs
@@ -600,7 +600,7 @@ impl Oryxis {
             section("vault", hk_hosts),
             indent(item(
                 "hosts",
-                Message::Navigation(NavigationMessage::ChangeView(View::Dashboard)),
+                Message::Navigation(NavigationMessage::GoHome),
                 self.hotkey_label_for_vault_slot(1)
             )),
             indent(item(

--- a/crates/oryxis-app/src/views/layout/menus.rs
+++ b/crates/oryxis-app/src/views/layout/menus.rs
@@ -600,7 +600,11 @@ impl Oryxis {
             section("vault", hk_hosts),
             indent(item(
                 "hosts",
-                Message::Navigation(NavigationMessage::GoHome),
+                // Mirrors the Hosts sub-nav pill (same list, same
+                // destination) and the shortcut this row renders next to
+                // itself: the vault section, at its root. The Home tab is
+                // the door that keeps the folder (`GoHome`).
+                Message::Navigation(NavigationMessage::ChangeView(View::Dashboard)),
                 self.hotkey_label_for_vault_slot(1)
             )),
             indent(item(

--- a/crates/oryxis-app/src/views/tab_bar/entry.rs
+++ b/crates/oryxis-app/src/views/tab_bar/entry.rs
@@ -57,7 +57,7 @@ impl Oryxis {
         area_tab(
             "",
             iced_fonts::lucide::house(),
-            View::Dashboard,
+            Message::Navigation(NavigationMessage::GoHome),
             nav_active && in_vault_area,
             solid_fill,
         )

--- a/crates/oryxis-app/src/views/tab_bar/mod.rs
+++ b/crates/oryxis-app/src/views/tab_bar/mod.rs
@@ -61,7 +61,7 @@ pub(crate) const CHIP_W: f32 = 38.0;
 /// Maximum width a tab claims when it has the room. Sized to fit a typical
 /// label like "user@hostname.example.com" without truncation. The active
 /// tab always uses this; inactives only when there's space.
-pub(crate) const TAB_NATURAL_WIDTH: f32 = 200.0;
+pub(crate) const TAB_NATURAL_WIDTH: f32 = 240.0;
 /// Floor below which we don't shrink, once a tab gets this narrow the
 /// label is mostly ellipses anyway, and going lower kills hit-target ergonomics.
 /// Picked to fit "OS-badge + ~8 chars + ellipsis" comfortably.

--- a/crates/oryxis-app/src/views/tab_bar/tabs.rs
+++ b/crates/oryxis-app/src/views/tab_bar/tabs.rs
@@ -4,7 +4,7 @@ use super::*;
 pub(crate) fn area_tab<'a>(
     label: &'a str,
     glyph: iced::widget::Text<'a>,
-    view: View,
+    on_press: Message,
     is_active: bool,
     solid_fill: bool,
 ) -> Element<'a, Message> {
@@ -50,7 +50,7 @@ pub(crate) fn area_tab<'a>(
                 .center_y(Length::Fixed(SQUARE)),
         )
         .padding(0)
-        .on_press(Message::Navigation(NavigationMessage::ChangeView(view)))
+        .on_press(on_press.clone())
         .style(style)
         .into()
     } else {
@@ -75,7 +75,7 @@ pub(crate) fn area_tab<'a>(
             .center_y(Length::Fixed(TAB_HEIGHT))
             .padding(Padding { top: 0.0, right: 10.0, bottom: 0.0, left: 6.0 }),
         )
-        .on_press(Message::Navigation(NavigationMessage::ChangeView(view)))
+        .on_press(on_press)
         .style(style)
         .into()
     };

--- a/crates/oryxis-app/src/views/tab_bar/tabs.rs
+++ b/crates/oryxis-app/src/views/tab_bar/tabs.rs
@@ -50,7 +50,7 @@ pub(crate) fn area_tab<'a>(
                 .center_y(Length::Fixed(SQUARE)),
         )
         .padding(0)
-        .on_press(on_press.clone())
+        .on_press(on_press)
         .style(style)
         .into()
     } else {

--- a/crates/oryxis-app/tests/e2e/clipboard-paths.ice
+++ b/crates/oryxis-app/tests/e2e/clipboard-paths.ice
@@ -37,7 +37,7 @@ screenshot sftp-path-paste
 # 2. Terminal copy-on-select: the widget queues the copy and the app
 #    performs it through the runtime, so it lands in the emulated
 #    clipboard (before the fix it went straight to the system clipboard).
-click (293, 20)
+click (333, 20)
 expect "Local Shell"
 click "Local Shell"
 timeout 500

--- a/crates/oryxis-app/tests/e2e/home-tab-keeps-folder.ice
+++ b/crates/oryxis-app/tests/e2e/home-tab-keeps-folder.ice
@@ -1,0 +1,57 @@
+viewport: 1200x750
+mode: Zen
+-----
+# Two doors into the host list, two answers, and this test pins both.
+#
+# The Home tab (house chip) comes back to the FOLDER the user was
+# standing in; the Hosts entries (sub-nav pill, burger row, and the
+# shortcut they render) stay the one-click way back out to the root.
+#
+# The discriminator is the subgroup: "WebTier" only renders while
+# "Prod" is open, so an `expect` on it proves which of the two the
+# click landed on. "Groups" is the mirror image: the root list's
+# section header, absent inside a folder.
+click "Skip"
+click "Continue without password"
+settle 250
+# A group at the root, then a subgroup inside it.
+click "New group"
+settle 250
+click (900.00, 145.00)
+type "Prod"
+settle 250
+click "Save"
+settle 250
+click "Prod"
+settle 250
+# The "+ HOST" split menu carries "New subgroup" while a folder is open.
+click (1149.00, 119.00)
+settle 250
+click "New subgroup"
+settle 250
+click (900.00, 145.00)
+type "WebTier"
+settle 250
+click "Save"
+settle 250
+expect "WebTier"
+# Leave the vault surface entirely, then come back through the house
+# chip: the folder survives the round trip.
+click "Keychain"
+settle 250
+click (57.00, 20.00)
+settle 250
+expect "WebTier"
+# The sub-nav pill is the opposite door: root, from inside the folder.
+click "Hosts"
+settle 250
+expect "Groups"
+# And its burger row mirrors the pill rather than the house chip (it
+# renders the pill's shortcut next to itself, so they must agree).
+click "Prod"
+settle 250
+click (19.00, 20.00)
+settle 250
+click (55.00, 91.00)
+settle 250
+expect "Groups"


### PR DESCRIPTION
### Changes

**1. Active tab width: 200 -> 240 px**

Matches Termius's wider active tab so longer hostnames like `user@hostname.example.com` don't truncate. Inactive tabs stay content-hugged at 110-200 px.

**2. Home button preserves the current group folder**

Previously, clicking Home or the burger-menu Hosts entry always reset to the root host list. Now:

- Inside a folder -> stays in that folder
- At root -> goes to Dashboard root (unchanged)
- `OpenGroup` now also switches to Dashboard view, so Home works from a terminal tab
- Toolbar back-arrow still navigates up one level