### PR TITLE
docs: document the oryxis-archive crate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ cd oryxis
 cargo run
 ```
 
-`docs/ARCHITECTURE.md` maps the 23-crate workspace; most UI work lands in
+`docs/ARCHITECTURE.md` maps the 24-crate workspace; most UI work lands in
 `crates/oryxis-app`, engine work in `oryxis-ssh` / `oryxis-vault` /
 `oryxis-sync` / `oryxis-terminal`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Oryxis is a Cargo workspace of 23 crates. The UI layer is an
+Oryxis is a Cargo workspace of 24 crates. The UI layer is an
 [iced](https://iced.rs) application on the wgpu backend; everything below it
 is a set of focused engines (SSH, Telnet, serial, vault, sync, terminal)
 that the app composes.
@@ -53,6 +53,7 @@ that the app composes.
 | `oryxis-telnet` | Native Telnet engine: RFC 854/855 option negotiation (RFC 1143 state machine), NAWS, terminal-type, charset transcoding |
 | `oryxis-serial` | Serial console sessions: COM / `/dev/tty*`, configurable baud, framing, flow control, line endings, local echo |
 | `oryxis-zmodem` | ZMODEM transfer engine: auto-detects `sz` / `rz` on the byte stream over SSH, Telnet and serial |
+| `oryxis-archive` | Archive operations for the SFTP file browser: browse and read/write zip and tar over local and remote (ranged) reads, transport-agnostic |
 | `oryxis-vault` | Encrypted vault: SQLite + Argon2id + ChaCha20-Poly1305 per-field + session logs / recordings + `.oryxis` export/import |
 | `oryxis-biometric` | Biometric / OS-keyring app unlock: Windows Hello, macOS Touch ID (Keychain user presence), Linux Secret Service |
 | `oryxis-sync` | P2P sync engine: QUIC (quinn) + mDNS + STUN + signaling + HTTP relay fallback + Ed25519/X25519 + LWW conflict resolution |


### PR DESCRIPTION
`docs/ARCHITECTURE.md` opens with "Oryxis is a Cargo workspace of 23 crates" and the `## Crates` table lists 23, but the workspace has 24 members: `oryxis-archive` is missing from both.

It is a real crate, not a stray entry:

- root `Cargo.toml` lists it as a workspace member
- `crates/oryxis-archive/` has its own source and `Cargo.toml`
- it is a dependency of `crates/oryxis-app`

`oryxis-gif` is intentionally in the workspace `exclude` list, so it stays uncounted and the correct number is 24 (not 25).

This corrects the count to 24, adds an `oryxis-archive` row to the Crates table (next to the other transfer crates, wording taken from its `lib.rs`), and updates the matching "23-crate" mention in `CONTRIBUTING.md`.
