### PR TITLE
fix(terminal): clear stale terminal modes on session attach

### DIFF
--- a/crates/oryxis-app/src/dispatch_ssh/session.rs
+++ b/crates/oryxis-app/src/dispatch_ssh/session.rs
@@ -286,6 +286,16 @@ impl Oryxis {
                     // The reconnect dial resolved; re-arm ReconnectTab.
                     pane.connecting = false;
                     if let Ok(mut state) = pane.terminal.lock() {
+                        // The shell that armed these modes is gone; the
+                        // fresh one never re-issued them, so clear the
+                        // leftovers before its first output arrives: stale
+                        // mouse tracking would keep the widget reporting
+                        // pointer moves into it (the shell's echo of those
+                        // reports lands on screen as garbage), stale
+                        // bracketed paste would wrap pastes the new shell
+                        // never asked for, and a cursor the old app hid
+                        // stays hidden. See `SESSION_ATTACH_MODE_RESET`.
+                        state.process(oryxis_terminal::SESSION_ATTACH_MODE_RESET);
                         // Serial has no viewport, so no resize sender;
                         // SSH/Telnet forward window changes to the peer.
                         if let Some(rtx) = session.resize_sender() {

--- a/crates/oryxis-app/src/dispatch_ssh/session.rs
+++ b/crates/oryxis-app/src/dispatch_ssh/session.rs
@@ -193,6 +193,19 @@ impl Oryxis {
                         // not be inherited by whatever the reconnect
                         // lands on.
                         p.triggers.clear();
+                        // The emulator's modes belong to the session too,
+                        // and the program that armed them is not around
+                        // to disarm them. Until they are cleared the dead
+                        // pane still reports the mouse to nobody instead
+                        // of selecting text, and the wheel still sends
+                        // arrow keys instead of walking the scrollback,
+                        // so the user cannot copy the output they
+                        // disconnected on. The alternate screen is left
+                        // alone on purpose: that frozen frame IS what
+                        // they are reading.
+                        if let Ok(mut state) = p.terminal.lock() {
+                            state.process(oryxis_terminal::SESSION_MODE_RESET);
+                        }
                         p.session_log_id
                     });
                     // Same for the suggestion popup, if it was this
@@ -286,16 +299,20 @@ impl Oryxis {
                     // The reconnect dial resolved; re-arm ReconnectTab.
                     pane.connecting = false;
                     if let Ok(mut state) = pane.terminal.lock() {
-                        // The shell that armed these modes is gone; the
-                        // fresh one never re-issued them, so clear the
-                        // leftovers before its first output arrives: stale
-                        // mouse tracking would keep the widget reporting
-                        // pointer moves into it (the shell's echo of those
-                        // reports lands on screen as garbage), stale
-                        // bracketed paste would wrap pastes the new shell
-                        // never asked for, and a cursor the old app hid
-                        // stays hidden. See `SESSION_ATTACH_MODE_RESET`.
-                        state.process(oryxis_terminal::SESSION_ATTACH_MODE_RESET);
+                        // Whatever armed the emulator's modes died with
+                        // the previous session, and the fresh shell never
+                        // re-issues them, so clear the leftovers before
+                        // its first output arrives. `SshDisconnected`
+                        // already cleared most of them, but this is the
+                        // one point EVERY session (ssh / telnet / serial,
+                        // fresh, reconnected or split) goes through, so
+                        // it stays the fail-safe rather than trusting a
+                        // disconnect message that a stalled transport may
+                        // never deliver. Alt screen first: leaving it
+                        // puts the cursor back in the real buffer, which
+                        // is where the region reset must land.
+                        state.process(oryxis_terminal::LEAVE_ALT_SCREEN);
+                        state.process(oryxis_terminal::SESSION_MODE_RESET);
                         // Serial has no viewport, so no resize sender;
                         // SSH/Telnet forward window changes to the peer.
                         if let Some(rtx) = session.resize_sender() {

--- a/crates/oryxis-terminal/src/lib.rs
+++ b/crates/oryxis-terminal/src/lib.rs
@@ -26,6 +26,18 @@ pub use widget::{
 };
 pub use pty::PtyHandle;
 
+/// DECRST/DECSET sequence the app feeds a pane the moment a fresh
+/// session attaches (`Oryxis::wire_connected_pane`): clears the
+/// emulator modes a previous session's apps may have left armed —
+/// mouse tracking (1000/1002/1003), SGR mouse encoding (1006),
+/// bracketed paste (2004) — and re-shows a cursor the old app hid.
+/// A fresh shell never re-issues those requests, so leaving them
+/// armed made the widget keep synthesizing mouse reports into a
+/// shell that did not ask for them, whose echo of those reports
+/// landed on screen as garbage after a reconnect.
+pub const SESSION_ATTACH_MODE_RESET: &[u8] =
+    b"\x1b[?1000;1002;1003;1006l\x1b[?2004l\x1b[?25h";
+
 // The backend exposes `Term` and grid types in its public surface
 // (`TerminalBackend::term`), so consumers that inspect the grid (the
 // app's session player tests, the harness) need the crate's types

--- a/crates/oryxis-terminal/src/lib.rs
+++ b/crates/oryxis-terminal/src/lib.rs
@@ -26,17 +26,41 @@ pub use widget::{
 };
 pub use pty::PtyHandle;
 
-/// DECRST/DECSET sequence the app feeds a pane the moment a fresh
-/// session attaches (`Oryxis::wire_connected_pane`): clears the
-/// emulator modes a previous session's apps may have left armed —
-/// mouse tracking (1000/1002/1003), SGR mouse encoding (1006),
-/// bracketed paste (2004) — and re-shows a cursor the old app hid.
-/// A fresh shell never re-issues those requests, so leaving them
-/// armed made the widget keep synthesizing mouse reports into a
-/// shell that did not ask for them, whose echo of those reports
-/// landed on screen as garbage after a reconnect.
-pub const SESSION_ATTACH_MODE_RESET: &[u8] =
-    b"\x1b[?1000;1002;1003;1006l\x1b[?2004l\x1b[?25h";
+/// DECRST/DECSET sequence the app feeds a pane when its session ends
+/// and again when a fresh one attaches (`dispatch_ssh::session`).
+///
+/// A mode belongs to the program that armed it, and a program killed
+/// by a dropped connection never gets to disarm its own: mouse
+/// tracking (1000/1002/1003 and its 1005/1006 encodings), focus
+/// reporting (1004), bracketed paste (2004), application cursor keys
+/// (1), autowrap (7), cursor visibility (25) and the scrolling region
+/// all outlive it. Each one either changes the bytes the WIDGET
+/// synthesizes or takes something away from the user, so leaving them
+/// armed made the widget keep reporting pointer moves into a shell
+/// that never asked for them (the shell's echo of those reports is
+/// the post-reconnect garbage), left local selection and scrollback
+/// disabled on a pane whose session was already dead, and kept a
+/// cursor a dead app hid hidden.
+///
+/// The reset is spelled out mode by mode because the emulator
+/// implements neither RIS nor DECSTR, and the scrolling region is
+/// reset between DECSC / DECRC since DECSTBM homes the cursor as a
+/// side effect. What the previous session PRINTED is deliberately
+/// untouched: this restores the terminal's input contract, not a
+/// blank pane. See [`LEAVE_ALT_SCREEN`] for the half only an attach
+/// sends.
+pub const SESSION_MODE_RESET: &[u8] =
+    b"\x1b[?1;1000;1002;1003;1004;1005;1006;2004l\x1b[?7;25h\x1b7\x1b[r\x1b8";
+
+/// DECRST 1049, sent right before [`SESSION_MODE_RESET`] when a fresh
+/// session attaches: a full-screen app the connection killed leaves the
+/// pane on the alternate screen, where the new shell would paint over
+/// the dead app's frame and the real buffer plus its scrollback would
+/// stay unreachable. Leaving it is exactly what the app itself would
+/// have done on a clean exit, and it is a no-op on a pane that never
+/// entered. A disconnect deliberately does NOT send it: the frozen
+/// frame is what the user is still reading.
+pub const LEAVE_ALT_SCREEN: &[u8] = b"\x1b[?1049l";
 
 // The backend exposes `Term` and grid types in its public surface
 // (`TerminalBackend::term`), so consumers that inspect the grid (the

--- a/crates/oryxis-terminal/src/widget/tests.rs
+++ b/crates/oryxis-terminal/src/widget/tests.rs
@@ -361,3 +361,57 @@
         );
         assert!(ws.selection.is_none(), "an unfocused pane declines the chord");
     }
+
+    /// The attach-time reset the app feeds on every fresh session
+    /// (`SESSION_ATTACH_MODE_RESET`) must clear every mode the widget's
+    /// mouse-report gate reads. Guard for the reconnect-garbage bug: stale
+    /// 1000/1002/1003/1006 left by a dead session made the widget keep
+    /// synthesizing SGR reports into a shell that never asked for them,
+    /// and the shell's echo of those reports landed on screen as text.
+    /// Regression at the gate level: with the modes cleared, a pointer
+    /// move must produce NO report.
+    #[test]
+    fn attach_reset_clears_mouse_tracking_and_blocks_reports() {
+        use alacritty_terminal::term::TermMode;
+
+        let mut term = TerminalState::new_no_pty(80, 24).unwrap();
+        // A dead tmux/vim session left any-motion tracking (1003), SGR
+        // encoding (1006), bracketed paste (2004) and a hidden cursor.
+        term.process(b"\x1b[?1003h\x1b[?1006h\x1b[?2004h\x1b[?25l");
+        assert!(
+            term.backend.term.mode().intersects(TermMode::MOUSE_MODE),
+            "precondition: stale mouse tracking armed"
+        );
+
+        term.process(crate::SESSION_ATTACH_MODE_RESET);
+
+        let mode = *term.backend.term.mode();
+        assert!(
+            !mode.intersects(TermMode::MOUSE_MODE),
+            "mouse tracking cleared"
+        );
+        assert!(!mode.contains(TermMode::SGR_MOUSE), "SGR encoding cleared");
+        assert!(
+            !mode.contains(TermMode::BRACKETED_PASTE),
+            "bracketed paste cleared"
+        );
+        assert!(mode.contains(TermMode::SHOW_CURSOR), "cursor shown again");
+
+        // The widget's report gate reads the mode back from the state: a
+        // pointer move must not synthesize a report any more.
+        let view = TerminalView::<()>::new(Arc::new(Mutex::new(term)));
+        let mut ws = TerminalWidgetState::default();
+        let ev = iced::Event::Mouse(mouse::Event::CursorMoved {
+            position: Point::new(40.0, 40.0),
+        });
+        let action = view.handle_mouse_report(
+            &mut ws,
+            &ev,
+            bounds(),
+            mouse::Cursor::Available(Point::new(40.0, 40.0)),
+            mode,
+            80,
+            24,
+        );
+        assert!(action.is_none(), "no SGR report after the attach reset");
+    }

--- a/crates/oryxis-terminal/src/widget/tests.rs
+++ b/crates/oryxis-terminal/src/widget/tests.rs
@@ -362,8 +362,20 @@
         assert!(ws.selection.is_none(), "an unfocused pane declines the chord");
     }
 
-    /// The attach-time reset the app feeds on every fresh session
-    /// (`SESSION_ATTACH_MODE_RESET`) must clear every mode the widget's
+    /// Everything a dead session can leave armed, in one pane, so the
+    /// reset is asserted against the state it exists for.
+    fn state_with_stale_modes() -> TerminalState {
+        let mut term = TerminalState::new_no_pty(80, 24).unwrap();
+        // What a killed tmux / vim leaves behind: any-motion tracking
+        // (1003) with both encodings (1005/1006), focus reporting (1004),
+        // bracketed paste (2004), application cursor keys (1), autowrap
+        // off (7) and a hidden cursor (25).
+        term.process(b"\x1b[?1;1003;1004;1005;1006;2004h\x1b[?7;25l");
+        term
+    }
+
+    /// The reset the app feeds on disconnect and on every fresh session
+    /// (`SESSION_MODE_RESET`) must clear every mode the widget's
     /// mouse-report gate reads. Guard for the reconnect-garbage bug: stale
     /// 1000/1002/1003/1006 left by a dead session made the widget keep
     /// synthesizing SGR reports into a shell that never asked for them,
@@ -371,19 +383,16 @@
     /// Regression at the gate level: with the modes cleared, a pointer
     /// move must produce NO report.
     #[test]
-    fn attach_reset_clears_mouse_tracking_and_blocks_reports() {
+    fn session_reset_clears_mouse_tracking_and_blocks_reports() {
         use alacritty_terminal::term::TermMode;
 
-        let mut term = TerminalState::new_no_pty(80, 24).unwrap();
-        // A dead tmux/vim session left any-motion tracking (1003), SGR
-        // encoding (1006), bracketed paste (2004) and a hidden cursor.
-        term.process(b"\x1b[?1003h\x1b[?1006h\x1b[?2004h\x1b[?25l");
+        let mut term = state_with_stale_modes();
         assert!(
             term.backend.term.mode().intersects(TermMode::MOUSE_MODE),
             "precondition: stale mouse tracking armed"
         );
 
-        term.process(crate::SESSION_ATTACH_MODE_RESET);
+        term.process(crate::SESSION_MODE_RESET);
 
         let mode = *term.backend.term.mode();
         assert!(
@@ -391,10 +400,20 @@
             "mouse tracking cleared"
         );
         assert!(!mode.contains(TermMode::SGR_MOUSE), "SGR encoding cleared");
+        assert!(!mode.contains(TermMode::UTF8_MOUSE), "UTF-8 encoding cleared");
+        assert!(
+            !mode.contains(TermMode::FOCUS_IN_OUT),
+            "focus reporting cleared"
+        );
         assert!(
             !mode.contains(TermMode::BRACKETED_PASTE),
             "bracketed paste cleared"
         );
+        assert!(
+            !mode.contains(TermMode::APP_CURSOR),
+            "application cursor keys cleared"
+        );
+        assert!(mode.contains(TermMode::LINE_WRAP), "autowrap back on");
         assert!(mode.contains(TermMode::SHOW_CURSOR), "cursor shown again");
 
         // The widget's report gate reads the mode back from the state: a
@@ -413,5 +432,77 @@
             80,
             24,
         );
-        assert!(action.is_none(), "no SGR report after the attach reset");
+        assert!(action.is_none(), "no SGR report after the session reset");
+    }
+
+    /// The scrolling region a dead full-screen app left behind would pin
+    /// the new shell's output inside its band, and DECSTBM homes the
+    /// cursor, which is why the reset wraps it in DECSC/DECRC: the
+    /// region goes back to the whole screen and the cursor stays where
+    /// the session left it.
+    #[test]
+    fn session_reset_restores_the_scrolling_region_without_moving_the_cursor() {
+        use alacritty_terminal::index::{Column, Line};
+
+        let mut term = TerminalState::new_no_pty(80, 24).unwrap();
+        // A band over the top 5 lines, cursor parked inside the pane.
+        term.process(b"\x1b[1;5r\x1b[10;3H");
+        let before = term.backend.term.grid().cursor.point;
+        assert_eq!(before, alacritty_terminal::index::Point::new(Line(9), Column(2)));
+
+        term.process(crate::SESSION_MODE_RESET);
+        assert_eq!(
+            term.backend.term.grid().cursor.point, before,
+            "the region reset must not home the cursor"
+        );
+
+        // One line per row, no trailing newline: with the band still
+        // armed the text would scroll inside rows 1-5 and the bottom of
+        // the screen would stay empty.
+        term.process(b"\x1b[H");
+        for i in 0..24 {
+            term.process(format!("L{i}").as_bytes());
+            if i < 23 {
+                term.process(b"\r\n");
+            }
+        }
+        let last = (0..3)
+            .map(|c| term.backend.term.grid()[Line(23)][Column(c)].c)
+            .collect::<String>();
+        assert_eq!(last, "L23", "output must reach the bottom row again");
+    }
+
+    /// A connection killed inside tmux / vim leaves the pane on the
+    /// alternate screen. `LEAVE_ALT_SCREEN` puts it back on the real
+    /// buffer (with its scrollback) exactly as the app's own clean exit
+    /// would have, and is a no-op on a pane that never entered.
+    #[test]
+    fn leave_alt_screen_restores_the_primary_buffer() {
+        use alacritty_terminal::index::{Column, Line};
+        use alacritty_terminal::term::TermMode;
+
+        let mut term = TerminalState::new_no_pty(80, 24).unwrap();
+        term.process(b"shell output");
+        // A full-screen app takes over and dies mid-frame.
+        term.process(b"\x1b[?1049h\x1b[Happ frame");
+        assert!(term.backend.term.mode().contains(TermMode::ALT_SCREEN));
+
+        term.process(crate::LEAVE_ALT_SCREEN);
+
+        assert!(
+            !term.backend.term.mode().contains(TermMode::ALT_SCREEN),
+            "back on the primary buffer"
+        );
+        let row0 = (0..12)
+            .map(|c| term.backend.term.grid()[Line(0)][Column(c)].c)
+            .collect::<String>();
+        assert_eq!(row0, "shell output", "the real buffer is back");
+
+        // Idempotent: a pane that never entered stays put.
+        term.process(crate::LEAVE_ALT_SCREEN);
+        assert!(!term.backend.term.mode().contains(TermMode::ALT_SCREEN));
+        let row0 = (0..12)
+            .map(|c| term.backend.term.grid()[Line(0)][Column(c)].c)
+            .collect::<String>();
+        assert_eq!(row0, "shell output");
     }


### PR DESCRIPTION
**Problem**

After an SSH / Telnet / Serial connection drops and reconnects, the terminal continuously prints garbage like:

    43M35;61;43M35;62;43M35;63;43M35;65;51M35;107;47M35;107

making the pane unusable. The noise grows as the mouse moves and never stops.

**Root cause**

A mode belongs to the program that armed it, and a program killed by a dropped connection never gets to disarm its own.

When a remote app (tmux with `set -g mouse on`, vim, htop) enables mouse tracking, it sends `DECSET 1000/1002/1003` plus an encoding (`1005`/`1006`), which the emulator records in its `TermMode`. When the connection drops, those bits stay armed. On reconnect the shell is a brand-new process that never requested mouse tracking, but the emulator still believes it should report mouse activity:

1. the widget keeps synthesizing SGR mouse reports (`ESC [ < Cb ; Cx ; Cy M`) into the new shell's stdin on every pointer move;
2. the shell's tty has echo enabled, so it echoes the reports back;
3. the echoed bytes (ESC prefix mangled by the echo path) are fed back into the emulator and rendered as literal text, the garbage the user sees.

Mouse tracking is the loudest symptom, not the whole class. The same leak leaves focus reporting (`1004`), bracketed paste (`2004`), application cursor keys (`1`), autowrap (`7`), cursor visibility (`25`) and the scrolling region armed for whatever the reconnect lands on, and a dead full-screen app leaves the pane stranded on the alternate screen, where the new shell paints over the corpse of its frame while the real buffer and its scrollback stay unreachable.

**The fix**

Two byte sequences in `oryxis-terminal`, fed through the same vte parser that consumes remote output, so mode bookkeeping can never drift from the emulator's own:

- `SESSION_MODE_RESET` disarms every mode above and restores the scrolling region. It is spelled out mode by mode because the emulator implements neither RIS nor DECSTR, and the region reset is wrapped in `DECSC`/`DECRC` because `DECSTBM` homes the cursor as a side effect.
- `LEAVE_ALT_SCREEN` (`DECRST 1049`) puts the pane back on the primary buffer. It is a restore, not a wipe: it is exactly what the app itself would have done on a clean exit, and it is a no-op on a pane that never entered.

The reset runs at **both** ends of a session's life:

- **On disconnect** (`SshDisconnected`), because until the modes are cleared a dead pane still reports the mouse to nobody instead of selecting text, and the wheel still sends arrow keys instead of walking the scrollback, so the user cannot copy the very output they disconnected on. The alternate screen is deliberately left alone here: that frozen frame is what the user is still reading.
- **On attach** (`wire_connected_pane`), before any of the new shell's output arrives. This is the fail-safe: it is the one point every SSH / Telnet / Serial session goes through (fresh connect, auto or manual reconnect, split pane), while a disconnect is a message a stalled transport may never deliver. A session that is never reconnected would otherwise never get the attach-time reset at all. Here `LEAVE_ALT_SCREEN` goes first, so the region reset lands on the real buffer.

What the previous session PRINTED is untouched throughout: this restores the terminal's input contract, not a blank pane.

**Changes**

- `crates/oryxis-terminal/src/lib.rs`: `SESSION_MODE_RESET` and `LEAVE_ALT_SCREEN` constants (single source of truth, shared with the regression tests).
- `crates/oryxis-app/src/dispatch_ssh/session.rs`: feed the reset on disconnect and on attach.
- `crates/oryxis-terminal/src/widget/tests.rs`: three regression tests, at the widget gate (a stale `1003/1006` mix, the reset, then a pointer move must produce no report), on the scrolling region (restored without homing the cursor, output reaches the bottom row again) and on the alternate screen (primary buffer and its content back, idempotent on a pane that never entered).

**Validation**

- `cargo test -p oryxis-terminal`: 196 passed.
- `cargo test --workspace --lib --bins` and `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- The new tests were proven to fail against the shorter sequence they replace.
- Manual check on a real host: reconnect, move the mouse, paste immediately, verify the cursor, all behave like a fresh terminal.
