### PR TITLE
feat(editor): reveal stored host credentials via the eye toggle

### DIFF
--- a/crates/oryxis-app/src/dispatch_cloud/discovery/panel.rs
+++ b/crates/oryxis-app/src/dispatch_cloud/discovery/panel.rs
@@ -19,6 +19,8 @@ impl Oryxis {
                 self.overlay = None;
                 // Close any other right-panel (mutually exclusive slot).
                 self.panels.host_panel = false;
+                // Sweep revealed stored secrets (typed edits survive).
+                self.sweep_editor_secrets();
                 self.cloud_form.visible = false;
                 self.cloud_dynamic_form.visible = false;
                 self.group_edit.visible = false;

--- a/crates/oryxis-app/src/dispatch_cloud/discovery/panel.rs
+++ b/crates/oryxis-app/src/dispatch_cloud/discovery/panel.rs
@@ -19,8 +19,8 @@ impl Oryxis {
                 self.overlay = None;
                 // Close any other right-panel (mutually exclusive slot).
                 self.panels.host_panel = false;
-                // Sweep revealed stored secrets (typed edits survive).
-                self.sweep_editor_secrets();
+                // Drop what the host editor's eyes revealed.
+                self.editor_form.sweep_secrets();
                 self.cloud_form.visible = false;
                 self.cloud_dynamic_form.visible = false;
                 self.group_edit.visible = false;

--- a/crates/oryxis-app/src/dispatch_cloud/dynamic_group.rs
+++ b/crates/oryxis-app/src/dispatch_cloud/dynamic_group.rs
@@ -119,6 +119,8 @@ impl Oryxis {
                 // other panel that's currently open so the user
                 // doesn't end up with two side-by-side editors.
                 self.panels.host_panel = false;
+                // Sweep revealed stored secrets (typed edits survive).
+                self.sweep_editor_secrets();
                 self.cloud_form.visible = false;
                 self.cloud_discover.visible = false;
                 self.group_edit.visible = false;

--- a/crates/oryxis-app/src/dispatch_cloud/dynamic_group.rs
+++ b/crates/oryxis-app/src/dispatch_cloud/dynamic_group.rs
@@ -119,8 +119,8 @@ impl Oryxis {
                 // other panel that's currently open so the user
                 // doesn't end up with two side-by-side editors.
                 self.panels.host_panel = false;
-                // Sweep revealed stored secrets (typed edits survive).
-                self.sweep_editor_secrets();
+                // Drop what the host editor's eyes revealed.
+                self.editor_form.sweep_secrets();
                 self.cloud_form.visible = false;
                 self.cloud_discover.visible = false;
                 self.group_edit.visible = false;

--- a/crates/oryxis-app/src/dispatch_cloud/form.rs
+++ b/crates/oryxis-app/src/dispatch_cloud/form.rs
@@ -63,6 +63,8 @@ impl Oryxis {
                 self.overlay = None;
                 // Close any other right-panel (mutually exclusive slot).
                 self.panels.host_panel = false;
+                // Sweep revealed stored secrets (typed edits survive).
+                self.sweep_editor_secrets();
                 self.cloud_dynamic_form.visible = false;
                 self.cloud_discover.visible = false;
                 self.group_edit.visible = false;

--- a/crates/oryxis-app/src/dispatch_cloud/form.rs
+++ b/crates/oryxis-app/src/dispatch_cloud/form.rs
@@ -63,8 +63,8 @@ impl Oryxis {
                 self.overlay = None;
                 // Close any other right-panel (mutually exclusive slot).
                 self.panels.host_panel = false;
-                // Sweep revealed stored secrets (typed edits survive).
-                self.sweep_editor_secrets();
+                // Drop what the host editor's eyes revealed.
+                self.editor_form.sweep_secrets();
                 self.cloud_dynamic_form.visible = false;
                 self.cloud_discover.visible = false;
                 self.group_edit.visible = false;

--- a/crates/oryxis-app/src/dispatch_editor/identity.rs
+++ b/crates/oryxis-app/src/dispatch_editor/identity.rs
@@ -21,14 +21,51 @@ impl Oryxis {
                 self.editor_form.password.set(v.into_inner());
             }
             EditorMessage::EditorTogglePasswordVisibility => {
-                self.editor_form.password_visible = !self.editor_form.password_visible;
+                if self.editor_form.password_visible {
+                    // Hide: drop a prefilled (untouched) stored plaintext
+                    // right away; typed edits stay masked in the buffer.
+                    if !self.editor_form.password.touched() {
+                        self.editor_form.password.clear();
+                    }
+                    self.editor_form.password_visible = false;
+                } else {
+                    // Reveal on demand: a stored password is decrypted
+                    // into the buffer only for the moment it is shown
+                    // (prefill stays untouched, so an unedited field
+                    // still preserves the stored value on save).
+                    if !self.editor_form.password.touched()
+                        && let Some(id) = self.editor_form.editing_id
+                        && let Some(pw) = self.vault.as_ref()
+                            .and_then(|v| v.get_connection_password(&id).ok().flatten())
+                    {
+                        self.editor_form.password.prefill(pw);
+                    }
+                    self.editor_form.password_visible = true;
+                }
             }
             EditorMessage::EditorTotpChanged(v) => {
                 self.editor_form.username_focused = false;
                 self.editor_form.totp_secret.set(v.into_inner());
             }
             EditorMessage::EditorToggleTotpVisibility => {
-                self.editor_form.totp_visible = !self.editor_form.totp_visible;
+                if self.editor_form.totp_visible {
+                    // Hide: drop a prefilled (untouched) stored secret
+                    // right away; typed edits stay masked in the buffer.
+                    if !self.editor_form.totp_secret.touched() {
+                        self.editor_form.totp_secret.clear();
+                    }
+                    self.editor_form.totp_visible = false;
+                } else {
+                    // Reveal on demand, same lazy decrypt as the password.
+                    if !self.editor_form.totp_secret.touched()
+                        && let Some(id) = self.editor_form.editing_id
+                        && let Some(secret) = self.vault.as_ref()
+                            .and_then(|v| v.get_connection_totp_secret(&id).ok().flatten())
+                    {
+                        self.editor_form.totp_secret.prefill(secret);
+                    }
+                    self.editor_form.totp_visible = true;
+                }
             }
             EditorMessage::EditorUseTotpToggled => {
                 self.editor_form.use_totp = !self.editor_form.use_totp;

--- a/crates/oryxis-app/src/dispatch_editor/identity.rs
+++ b/crates/oryxis-app/src/dispatch_editor/identity.rs
@@ -21,51 +21,14 @@ impl Oryxis {
                 self.editor_form.password.set(v.into_inner());
             }
             EditorMessage::EditorTogglePasswordVisibility => {
-                if self.editor_form.password_visible {
-                    // Hide: drop a prefilled (untouched) stored plaintext
-                    // right away; typed edits stay masked in the buffer.
-                    if !self.editor_form.password.touched() {
-                        self.editor_form.password.clear();
-                    }
-                    self.editor_form.password_visible = false;
-                } else {
-                    // Reveal on demand: a stored password is decrypted
-                    // into the buffer only for the moment it is shown
-                    // (prefill stays untouched, so an unedited field
-                    // still preserves the stored value on save).
-                    if !self.editor_form.password.touched()
-                        && let Some(id) = self.editor_form.editing_id
-                        && let Some(pw) = self.vault.as_ref()
-                            .and_then(|v| v.get_connection_password(&id).ok().flatten())
-                    {
-                        self.editor_form.password.prefill(pw);
-                    }
-                    self.editor_form.password_visible = true;
-                }
+                self.toggle_editor_secret(super::EditorSecret::Password);
             }
             EditorMessage::EditorTotpChanged(v) => {
                 self.editor_form.username_focused = false;
                 self.editor_form.totp_secret.set(v.into_inner());
             }
             EditorMessage::EditorToggleTotpVisibility => {
-                if self.editor_form.totp_visible {
-                    // Hide: drop a prefilled (untouched) stored secret
-                    // right away; typed edits stay masked in the buffer.
-                    if !self.editor_form.totp_secret.touched() {
-                        self.editor_form.totp_secret.clear();
-                    }
-                    self.editor_form.totp_visible = false;
-                } else {
-                    // Reveal on demand, same lazy decrypt as the password.
-                    if !self.editor_form.totp_secret.touched()
-                        && let Some(id) = self.editor_form.editing_id
-                        && let Some(secret) = self.vault.as_ref()
-                            .and_then(|v| v.get_connection_totp_secret(&id).ok().flatten())
-                    {
-                        self.editor_form.totp_secret.prefill(secret);
-                    }
-                    self.editor_form.totp_visible = true;
-                }
+                self.toggle_editor_secret(super::EditorSecret::Totp);
             }
             EditorMessage::EditorUseTotpToggled => {
                 self.editor_form.use_totp = !self.editor_form.use_totp;

--- a/crates/oryxis-app/src/dispatch_editor/lifecycle.rs
+++ b/crates/oryxis-app/src/dispatch_editor/lifecycle.rs
@@ -7,32 +7,6 @@
 use super::*;
 
 impl Oryxis {
-    /// Sweep the host editor's secret buffers once the panel closes, so
-    /// a revealed (decrypted) stored value doesn't keep sitting in RAM
-    /// behind a closed panel. Only untouched buffers are cleared: those
-    /// hold the prefilled STORED plaintext shown by the eye toggle,
-    /// which the vault re-decrypts on demand the next time the eye is
-    /// opened. A touched buffer holds the user's own typing (new host /
-    /// replaced password); the author's original code always let that
-    /// linger until the next editor open, and sweeping it would eat
-    /// work-in-progress when the panel is merely switched to another
-    /// one. `clear()` never sets the touched flag, so the tri-state save
-    /// semantics are untouched.
-    pub(crate) fn sweep_editor_secrets(&mut self) {
-        if !self.editor_form.password.touched() {
-            self.editor_form.password.clear();
-        }
-        if !self.editor_form.proxy_password.touched() {
-            self.editor_form.proxy_password.clear();
-        }
-        if !self.editor_form.totp_secret.touched() {
-            self.editor_form.totp_secret.clear();
-        }
-        if !self.editor_form.target_password.touched() {
-            self.editor_form.target_password.clear();
-        }
-    }
-
     pub(super) fn handle_editor_lifecycle(&mut self, message: EditorMessage) -> Task<Message> {
         match message {
             EditorMessage::ShowNewConnection => {
@@ -252,7 +226,7 @@ impl Oryxis {
                             self.host_panel_error = None;
                             // The save consumed the secrets; drop any
                             // plaintext the eye may have revealed.
-                            self.sweep_editor_secrets();
+                            self.editor_form.sweep_secrets();
                             // Re-paint any open tabs of this host so a
                             // newly chosen palette takes effect without
                             // a reconnect.
@@ -326,16 +300,16 @@ impl Oryxis {
                 self.host_panel_error = None;
                 // The typed secrets rode into the quick-connect entry;
                 // drop any revealed plaintext from the form buffers.
-                self.sweep_editor_secrets();
+                self.editor_form.sweep_secrets();
                 return self.update(Message::Ssh(SshMessage::QuickConnect(Box::new(entry))));
             }
             EditorMessage::EditorCancel => {
                 self.panels.host_panel = false;
                 self.panel_nav_clear();
                 self.host_panel_error = None;
-                // Nothing was saved; sweep revealed stored plaintext
-                // (typed edits survive, the author's original behavior).
-                self.sweep_editor_secrets();
+                // Nothing was written, so there is nothing to preserve
+                // but the user's own typing.
+                self.editor_form.sweep_secrets();
             }
             EditorMessage::RequestDeleteConnection(idx) => {
                 if let Some(conn) = self.connections.get(idx) {
@@ -356,7 +330,7 @@ impl Oryxis {
                         let _ = vault.delete_chat_conversations_for_connection(&id);
                         self.panels.host_panel = false;
                         self.panel_nav_clear();
-                        self.sweep_editor_secrets();
+                        self.editor_form.sweep_secrets();
                         self.load_data_from_vault();
                     }
                 }

--- a/crates/oryxis-app/src/dispatch_editor/lifecycle.rs
+++ b/crates/oryxis-app/src/dispatch_editor/lifecycle.rs
@@ -7,6 +7,32 @@
 use super::*;
 
 impl Oryxis {
+    /// Sweep the host editor's secret buffers once the panel closes, so
+    /// a revealed (decrypted) stored value doesn't keep sitting in RAM
+    /// behind a closed panel. Only untouched buffers are cleared: those
+    /// hold the prefilled STORED plaintext shown by the eye toggle,
+    /// which the vault re-decrypts on demand the next time the eye is
+    /// opened. A touched buffer holds the user's own typing (new host /
+    /// replaced password); the author's original code always let that
+    /// linger until the next editor open, and sweeping it would eat
+    /// work-in-progress when the panel is merely switched to another
+    /// one. `clear()` never sets the touched flag, so the tri-state save
+    /// semantics are untouched.
+    pub(crate) fn sweep_editor_secrets(&mut self) {
+        if !self.editor_form.password.touched() {
+            self.editor_form.password.clear();
+        }
+        if !self.editor_form.proxy_password.touched() {
+            self.editor_form.proxy_password.clear();
+        }
+        if !self.editor_form.totp_secret.touched() {
+            self.editor_form.totp_secret.clear();
+        }
+        if !self.editor_form.target_password.touched() {
+            self.editor_form.target_password.clear();
+        }
+    }
+
     pub(super) fn handle_editor_lifecycle(&mut self, message: EditorMessage) -> Task<Message> {
         match message {
             EditorMessage::ShowNewConnection => {
@@ -224,6 +250,9 @@ impl Oryxis {
                             self.panels.host_panel = false;
                             self.panel_nav_clear();
                             self.host_panel_error = None;
+                            // The save consumed the secrets; drop any
+                            // plaintext the eye may have revealed.
+                            self.sweep_editor_secrets();
                             // Re-paint any open tabs of this host so a
                             // newly chosen palette takes effect without
                             // a reconnect.
@@ -295,12 +324,18 @@ impl Oryxis {
                 self.panels.host_panel = false;
                 self.panel_nav_clear();
                 self.host_panel_error = None;
+                // The typed secrets rode into the quick-connect entry;
+                // drop any revealed plaintext from the form buffers.
+                self.sweep_editor_secrets();
                 return self.update(Message::Ssh(SshMessage::QuickConnect(Box::new(entry))));
             }
             EditorMessage::EditorCancel => {
                 self.panels.host_panel = false;
                 self.panel_nav_clear();
                 self.host_panel_error = None;
+                // Nothing was saved; sweep revealed stored plaintext
+                // (typed edits survive, the author's original behavior).
+                self.sweep_editor_secrets();
             }
             EditorMessage::RequestDeleteConnection(idx) => {
                 if let Some(conn) = self.connections.get(idx) {
@@ -321,6 +356,7 @@ impl Oryxis {
                         let _ = vault.delete_chat_conversations_for_connection(&id);
                         self.panels.host_panel = false;
                         self.panel_nav_clear();
+                        self.sweep_editor_secrets();
                         self.load_data_from_vault();
                     }
                 }

--- a/crates/oryxis-app/src/dispatch_editor/login_script.rs
+++ b/crates/oryxis-app/src/dispatch_editor/login_script.rs
@@ -137,8 +137,27 @@ impl Oryxis {
                 self.editor_form.target_password.set(v.into_inner());
             }
             EditorMessage::EditorToggleTargetPasswordVisibility => {
-                self.editor_form.target_password_visible =
-                    !self.editor_form.target_password_visible;
+                if self.editor_form.target_password_visible {
+                    // Hide: drop a prefilled (untouched) stored plaintext
+                    // right away; typed edits stay masked in the buffer.
+                    if !self.editor_form.target_password.touched() {
+                        self.editor_form.target_password.clear();
+                    }
+                    self.editor_form.target_password_visible = false;
+                } else {
+                    // Reveal on demand: a stored target password is
+                    // decrypted into the buffer only for the moment it is
+                    // shown (prefill stays untouched, so an unedited
+                    // field still preserves the stored value on save).
+                    if !self.editor_form.target_password.touched()
+                        && let Some(id) = self.editor_form.editing_id
+                        && let Some(pw) = self.vault.as_ref()
+                            .and_then(|v| v.get_connection_target_password(&id).ok().flatten())
+                    {
+                        self.editor_form.target_password.prefill(pw);
+                    }
+                    self.editor_form.target_password_visible = true;
+                }
             }
             EditorMessage::EditorScriptDraftTemplateChanged(choice) => {
                 let template = if choice == crate::i18n::t("login_script_tpl_jumpserver") {

--- a/crates/oryxis-app/src/dispatch_editor/login_script.rs
+++ b/crates/oryxis-app/src/dispatch_editor/login_script.rs
@@ -137,27 +137,7 @@ impl Oryxis {
                 self.editor_form.target_password.set(v.into_inner());
             }
             EditorMessage::EditorToggleTargetPasswordVisibility => {
-                if self.editor_form.target_password_visible {
-                    // Hide: drop a prefilled (untouched) stored plaintext
-                    // right away; typed edits stay masked in the buffer.
-                    if !self.editor_form.target_password.touched() {
-                        self.editor_form.target_password.clear();
-                    }
-                    self.editor_form.target_password_visible = false;
-                } else {
-                    // Reveal on demand: a stored target password is
-                    // decrypted into the buffer only for the moment it is
-                    // shown (prefill stays untouched, so an unedited
-                    // field still preserves the stored value on save).
-                    if !self.editor_form.target_password.touched()
-                        && let Some(id) = self.editor_form.editing_id
-                        && let Some(pw) = self.vault.as_ref()
-                            .and_then(|v| v.get_connection_target_password(&id).ok().flatten())
-                    {
-                        self.editor_form.target_password.prefill(pw);
-                    }
-                    self.editor_form.target_password_visible = true;
-                }
+                self.toggle_editor_secret(super::EditorSecret::TargetPassword);
             }
             EditorMessage::EditorScriptDraftTemplateChanged(choice) => {
                 let template = if choice == crate::i18n::t("login_script_tpl_jumpserver") {

--- a/crates/oryxis-app/src/dispatch_editor/mod.rs
+++ b/crates/oryxis-app/src/dispatch_editor/mod.rs
@@ -12,7 +12,72 @@ use oryxis_core::models::group::Group;
 use crate::app::{EditorMessage, SshMessage, Message, Oryxis};
 use crate::state::{ConnectionForm, EnvVarForm, PortForwardForm, ProxyKind};
 
+/// Which of the host editor's four secret fields an eye toggle acts
+/// on. The four flows are the same flow, differing only in the buffer
+/// and the encrypted column behind it, so they share one handler
+/// instead of four copies that can drift apart.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum EditorSecret {
+    Password,
+    ProxyPassword,
+    Totp,
+    TargetPassword,
+}
+
 impl Oryxis {
+    /// Flip one secret field's eye.
+    ///
+    /// Revealing DECRYPTS the stored value into the form buffer for
+    /// exactly as long as it is shown, hiding drops it again, and the
+    /// panel-close sweep ([`ConnectionForm::sweep_secrets`]) is the
+    /// backstop for the paths that never see a second click. The value
+    /// arrives through [`SecretInput::prefill`], which leaves the
+    /// buffer untouched, so a revealed-but-unedited field still
+    /// resolves to `None` (preserve the stored secret) on save.
+    ///
+    /// A buffer the user typed into is never overwritten by the
+    /// reveal, nor emptied by the hide: it is their text, not the
+    /// vault's, and it is already on screen.
+    pub(super) fn toggle_editor_secret(&mut self, which: EditorSecret) {
+        // Disjoint field borrows: the buffer below is borrowed out of
+        // the form, so anything else the form knows is read first.
+        let Self { editor_form: form, vault, .. } = self;
+        let editing_id = form.editing_id;
+        let (buffer, visible) = match which {
+            EditorSecret::Password => (&mut form.password, &mut form.password_visible),
+            EditorSecret::ProxyPassword => {
+                (&mut form.proxy_password, &mut form.proxy_password_visible)
+            }
+            EditorSecret::Totp => (&mut form.totp_secret, &mut form.totp_visible),
+            EditorSecret::TargetPassword => {
+                (&mut form.target_password, &mut form.target_password_visible)
+            }
+        };
+        if *visible {
+            if !buffer.touched() {
+                buffer.clear();
+            }
+            *visible = false;
+            return;
+        }
+        // A new host has no row to read from, and a sealed vault
+        // answers `Err`; both leave the field empty, which is what it
+        // already showed.
+        if !buffer.touched()
+            && let Some(id) = editing_id
+            && let Some(store) = vault.as_ref()
+            && let Ok(Some(secret)) = match which {
+                EditorSecret::Password => store.get_connection_password(&id),
+                EditorSecret::ProxyPassword => store.get_proxy_password(&id),
+                EditorSecret::Totp => store.get_connection_totp_secret(&id),
+                EditorSecret::TargetPassword => store.get_connection_target_password(&id),
+            }
+        {
+            buffer.prefill(secret);
+        }
+        *visible = true;
+    }
+
     /// A blank connection form pre-filled with the user's new-connection
     /// defaults (agent forwarding, port, keepalive, TERM), so they don't
     /// re-set the same fields on every new host.
@@ -676,6 +741,7 @@ impl Oryxis {
                 _ => None,
             }).unwrap_or_default(),
             has_existing_proxy_password: has_proxy_pw,
+            proxy_password_visible: false,
             // Never pre-fill the TOTP secret either; the
             // masked placeholder signals one is stored.
             totp_secret: Default::default(),
@@ -776,6 +842,7 @@ impl Oryxis {
                 | EditorMessage::EditorProxyPortChanged(..)
                 | EditorMessage::EditorProxyUsernameChanged(..)
                 | EditorMessage::EditorProxyPasswordChanged(..)
+                | EditorMessage::EditorToggleProxyPasswordVisibility
                 | EditorMessage::EditorProxyCommandChanged(..)
                 | EditorMessage::OpenChainEditor
                 | EditorMessage::CloseChainEditor

--- a/crates/oryxis-app/src/dispatch_editor/network.rs
+++ b/crates/oryxis-app/src/dispatch_editor/network.rs
@@ -55,6 +55,9 @@ impl Oryxis {
             EditorMessage::EditorProxyPasswordChanged(v) => {
                 self.editor_form.proxy_password.set(v.into_inner());
             }
+            EditorMessage::EditorToggleProxyPasswordVisibility => {
+                self.toggle_editor_secret(super::EditorSecret::ProxyPassword);
+            }
             EditorMessage::EditorProxyCommandChanged(v) => { self.editor_form.proxy_command = v; }
             EditorMessage::OpenChainEditor => {
                 self.panels.chain_editor = true;

--- a/crates/oryxis-app/src/dispatch_session_group.rs
+++ b/crates/oryxis-app/src/dispatch_session_group.rs
@@ -270,6 +270,8 @@ impl Oryxis {
     fn open_session_group_editor(&mut self, mut form: SessionGroupForm) -> Task<Message> {
         // Mutually exclusive right-panel slot, close other panels first.
         self.panels.host_panel = false;
+        // Sweep revealed stored secrets (typed edits survive).
+        self.sweep_editor_secrets();
         self.panel_nav_clear();
         self.cloud_form.visible = false;
         self.cloud_dynamic_form.visible = false;

--- a/crates/oryxis-app/src/dispatch_session_group.rs
+++ b/crates/oryxis-app/src/dispatch_session_group.rs
@@ -270,8 +270,8 @@ impl Oryxis {
     fn open_session_group_editor(&mut self, mut form: SessionGroupForm) -> Task<Message> {
         // Mutually exclusive right-panel slot, close other panels first.
         self.panels.host_panel = false;
-        // Sweep revealed stored secrets (typed edits survive).
-        self.sweep_editor_secrets();
+        // Drop what the host editor's eyes revealed.
+        self.editor_form.sweep_secrets();
         self.panel_nav_clear();
         self.cloud_form.visible = false;
         self.cloud_dynamic_form.visible = false;

--- a/crates/oryxis-app/src/dispatch_settings/hotkeys.rs
+++ b/crates/oryxis-app/src/dispatch_settings/hotkeys.rs
@@ -37,8 +37,30 @@ impl Oryxis {
                 }
             }
             SettingsMessage::ToggleSecretVisibility(field) => {
-                if !self.revealed_secrets.remove(&field) {
+                if self.revealed_secrets.remove(&field) {
+                    // Hiding: the host editor's stored proxy password was
+                    // decrypted into the buffer on reveal; drop it right
+                    // away. Typed buffers (AI key, vault passwords,
+                    // export/share) keep their text.
+                    if field == crate::state::SecretField::ProxyPassword
+                        && !self.editor_form.proxy_password.touched()
+                    {
+                        self.editor_form.proxy_password.clear();
+                    }
+                } else {
                     self.revealed_secrets.insert(field);
+                    // Revealing a stored proxy password on demand: decrypt
+                    // it into the buffer only for the moment it is shown
+                    // (prefill stays untouched, so an unedited field still
+                    // preserves the stored value on save).
+                    if field == crate::state::SecretField::ProxyPassword
+                        && !self.editor_form.proxy_password.touched()
+                        && let Some(id) = self.editor_form.editing_id
+                        && let Some(pw) = self.vault.as_ref()
+                            .and_then(|v| v.get_proxy_password(&id).ok().flatten())
+                    {
+                        self.editor_form.proxy_password.prefill(pw);
+                    }
                 }
             }
             m => return Err(m),

--- a/crates/oryxis-app/src/dispatch_settings/hotkeys.rs
+++ b/crates/oryxis-app/src/dispatch_settings/hotkeys.rs
@@ -37,30 +37,8 @@ impl Oryxis {
                 }
             }
             SettingsMessage::ToggleSecretVisibility(field) => {
-                if self.revealed_secrets.remove(&field) {
-                    // Hiding: the host editor's stored proxy password was
-                    // decrypted into the buffer on reveal; drop it right
-                    // away. Typed buffers (AI key, vault passwords,
-                    // export/share) keep their text.
-                    if field == crate::state::SecretField::ProxyPassword
-                        && !self.editor_form.proxy_password.touched()
-                    {
-                        self.editor_form.proxy_password.clear();
-                    }
-                } else {
+                if !self.revealed_secrets.remove(&field) {
                     self.revealed_secrets.insert(field);
-                    // Revealing a stored proxy password on demand: decrypt
-                    // it into the buffer only for the moment it is shown
-                    // (prefill stays untouched, so an unedited field still
-                    // preserves the stored value on save).
-                    if field == crate::state::SecretField::ProxyPassword
-                        && !self.editor_form.proxy_password.touched()
-                        && let Some(id) = self.editor_form.editing_id
-                        && let Some(pw) = self.vault.as_ref()
-                            .and_then(|v| v.get_proxy_password(&id).ok().flatten())
-                    {
-                        self.editor_form.proxy_password.prefill(pw);
-                    }
                 }
             }
             m => return Err(m),

--- a/crates/oryxis-app/src/dispatch_tabs/groups.rs
+++ b/crates/oryxis-app/src/dispatch_tabs/groups.rs
@@ -29,6 +29,8 @@ impl Oryxis {
                     self.group_edit.visible = true;
                     // Mutually exclusive with the other right-hand panels.
                     self.panels.host_panel = false;
+                    // Sweep revealed stored secrets (typed edits survive).
+                    self.sweep_editor_secrets();
                     self.panel_nav_clear();
                     self.panels.session_group_panel = false;
                     self.cloud_form.visible = false;
@@ -56,6 +58,8 @@ impl Oryxis {
                     };
                     // Mutually exclusive with the other right-hand panels.
                     self.panels.host_panel = false;
+                    // Sweep revealed stored secrets (typed edits survive).
+                    self.sweep_editor_secrets();
                     self.panel_nav_clear();
                     self.panels.session_group_panel = false;
                     self.cloud_form.visible = false;
@@ -79,6 +83,8 @@ impl Oryxis {
                 };
                 // Mutually exclusive with the other right-hand panels.
                 self.panels.host_panel = false;
+                // Sweep revealed stored secrets (typed edits survive).
+                self.sweep_editor_secrets();
                 self.panel_nav_clear();
                 self.panels.session_group_panel = false;
                 self.cloud_form.visible = false;

--- a/crates/oryxis-app/src/dispatch_tabs/groups.rs
+++ b/crates/oryxis-app/src/dispatch_tabs/groups.rs
@@ -29,8 +29,8 @@ impl Oryxis {
                     self.group_edit.visible = true;
                     // Mutually exclusive with the other right-hand panels.
                     self.panels.host_panel = false;
-                    // Sweep revealed stored secrets (typed edits survive).
-                    self.sweep_editor_secrets();
+                    // Drop what the host editor's eyes revealed.
+                    self.editor_form.sweep_secrets();
                     self.panel_nav_clear();
                     self.panels.session_group_panel = false;
                     self.cloud_form.visible = false;
@@ -58,8 +58,8 @@ impl Oryxis {
                     };
                     // Mutually exclusive with the other right-hand panels.
                     self.panels.host_panel = false;
-                    // Sweep revealed stored secrets (typed edits survive).
-                    self.sweep_editor_secrets();
+                    // Drop what the host editor's eyes revealed.
+                    self.editor_form.sweep_secrets();
                     self.panel_nav_clear();
                     self.panels.session_group_panel = false;
                     self.cloud_form.visible = false;
@@ -83,8 +83,8 @@ impl Oryxis {
                 };
                 // Mutually exclusive with the other right-hand panels.
                 self.panels.host_panel = false;
-                // Sweep revealed stored secrets (typed edits survive).
-                self.sweep_editor_secrets();
+                // Drop what the host editor's eyes revealed.
+                self.editor_form.sweep_secrets();
                 self.panel_nav_clear();
                 self.panels.session_group_panel = false;
                 self.cloud_form.visible = false;

--- a/crates/oryxis-app/src/messages/editor.rs
+++ b/crates/oryxis-app/src/messages/editor.rs
@@ -122,6 +122,11 @@ pub enum EditorMessage {
     EditorProxyPortChanged(String),
     EditorProxyUsernameChanged(String),
     EditorProxyPasswordChanged(super::Redacted),
+    /// Eye toggle for the inline proxy password. Was routed through the
+    /// shared `SettingsMessage::ToggleSecretVisibility` / `revealed_secrets`
+    /// set, which outlives the form it was describing; it is a form flag
+    /// like the other three eyes now.
+    EditorToggleProxyPasswordVisibility,
     EditorProxyCommandChanged(String),
     EditorTogglePasswordVisibility,
     /// TOTP secret (2FA) field: value edit + eye toggle. Tri-state save

--- a/crates/oryxis-app/src/state/forms.rs
+++ b/crates/oryxis-app/src/state/forms.rs
@@ -1,5 +1,7 @@
 //! Connection / session-group editor forms (split out of `state.rs`).
 
+use zeroize::Zeroize;
+
 use super::*;
 
 /// Add / edit form for a local terminal, shown in a modal from the
@@ -78,16 +80,45 @@ pub(crate) struct SessionGroupForm {
 /// that marks the buffer edited is [`set`](Self::set) (the `*Changed`
 /// message arms), and the only ways back are [`clear`](Self::clear) /
 /// [`prefill`](Self::prefill) (form open / reset / hydration).
-#[derive(Debug, Clone, Default)]
+///
+/// Every replacement of the buffer zeroizes what it displaces, and so
+/// does the drop, because the eye toggle now decrypts STORED secrets
+/// into it: a plain `self.value = other` would hand the old
+/// allocation back to the allocator with the plaintext still in it.
+/// This covers the buffer only. The `text_input` the buffer is bound
+/// to keeps its own copy of the value for rendering, and that copy is
+/// beyond our reach, so this narrows the exposure rather than closing
+/// it.
+#[derive(Clone, Default)]
 pub(crate) struct SecretInput {
     value: String,
     touched: bool,
+}
+
+/// Redacted by hand: the derived `Debug` would print the plaintext
+/// into any log line or panic message that formats a form. The
+/// touched flag is the only part worth debugging, and it is not
+/// secret.
+impl std::fmt::Debug for SecretInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SecretInput")
+            .field("value", &"<redacted>")
+            .field("touched", &self.touched)
+            .finish()
+    }
+}
+
+impl Drop for SecretInput {
+    fn drop(&mut self) {
+        self.value.zeroize();
+    }
 }
 
 impl SecretInput {
     /// User edit: assign the buffer and mark it touched, so a later
     /// [`resolve`](Self::resolve) writes (or clears) the vault value.
     pub fn set(&mut self, value: String) {
+        self.value.zeroize();
         self.value = value;
         self.touched = true;
     }
@@ -97,6 +128,7 @@ impl SecretInput {
     /// the hydration primitive; [`clear`](Self::clear) is its
     /// empty-string shorthand.
     pub fn prefill(&mut self, value: String) {
+        self.value.zeroize();
         self.value = value;
         self.touched = false;
     }
@@ -286,6 +318,11 @@ pub(crate) struct ConnectionForm {
     /// encrypted proxy password into form state on edit and lets save
     /// distinguish "preserve" from "explicitly cleared".
     pub has_existing_proxy_password: bool,
+    /// Whether the proxy password is shown in plain text. Lives on the
+    /// form, like the other three eyes, so opening another host starts
+    /// masked: the shared `revealed_secrets` set survives a form swap,
+    /// which left this one eye armed over an empty buffer.
+    pub proxy_password_visible: bool,
     /// TOTP secret input (bare Base32 or an otpauth:// URI) feeding the
     /// keyboard-interactive 2FA autofill. Same tri-state discipline as
     /// the passwords above.
@@ -442,6 +479,40 @@ impl ConnectionForm {
             AlgoCategory::Kex => &mut self.kex,
             AlgoCategory::Mac => &mut self.macs,
             AlgoCategory::HostKey => &mut self.host_key_algorithms,
+        }
+    }
+
+    /// The four secret buffers plus their eyes, as one walk. Written
+    /// once here so a fifth secret field joins the reveal, the sweep
+    /// and the close paths by adding a row instead of by being
+    /// remembered at each of them.
+    fn secret_fields(&mut self) -> [(&mut SecretInput, &mut bool); 4] {
+        [
+            (&mut self.password, &mut self.password_visible),
+            (&mut self.proxy_password, &mut self.proxy_password_visible),
+            (&mut self.totp_secret, &mut self.totp_visible),
+            (&mut self.target_password, &mut self.target_password_visible),
+        ]
+    }
+
+    /// Drop what the eye toggles revealed, once the host editor's
+    /// panel is gone. An UNTOUCHED buffer holds the stored plaintext
+    /// the eye decrypted, which the vault hands back on demand the
+    /// next time it is opened, so nothing is lost by emptying it. A
+    /// TOUCHED buffer is the user's own typing, and a panel that was
+    /// merely switched away from must not eat work in progress, so it
+    /// survives. [`SecretInput::clear`] never sets the touched flag,
+    /// which is what keeps the tri-state save semantics intact.
+    ///
+    /// The eyes close either way: a closed panel with an eye still
+    /// armed reopens showing an empty field in plaintext, which reads
+    /// as "no secret stored" and takes two clicks to undo.
+    pub(crate) fn sweep_secrets(&mut self) {
+        for (buffer, visible) in self.secret_fields() {
+            if !buffer.touched() {
+                buffer.clear();
+            }
+            *visible = false;
         }
     }
 }
@@ -1113,6 +1184,7 @@ impl Default for ConnectionForm {
             proxy_password: SecretInput::default(),
             proxy_command: String::new(),
             has_existing_proxy_password: false,
+            proxy_password_visible: false,
             totp_secret: SecretInput::default(),
             has_existing_totp: false,
             totp_visible: false,
@@ -1191,5 +1263,64 @@ mod secret_input_tests {
         assert_eq!(field.resolve(), None);
         assert_eq!(field.as_str(), "");
         assert!(!field.touched());
+    }
+
+    #[test]
+    fn debug_never_prints_the_value() {
+        // A form formatted into a log line or a panic message must not
+        // carry the secret with it.
+        let mut field = SecretInput::default();
+        field.set("s3cret".into());
+        let rendered = format!("{field:?}");
+        assert!(!rendered.contains("s3cret"), "{rendered}");
+        assert!(rendered.contains("touched: true"), "{rendered}");
+    }
+}
+
+#[cfg(test)]
+mod sweep_secrets_tests {
+    use super::ConnectionForm;
+
+    /// The whole contract of the panel-close sweep: what the eye
+    /// revealed goes, what the user typed stays, and every eye closes.
+    #[test]
+    fn sweeps_revealed_stored_secrets_and_keeps_typed_ones() {
+        let mut form = ConnectionForm::default();
+        // Two fields revealed from the vault (prefill = untouched)...
+        form.password.prefill("stored-pw".into());
+        form.password_visible = true;
+        form.proxy_password.prefill("stored-proxy".into());
+        form.proxy_password_visible = true;
+        // ...and two the user typed into.
+        form.totp_secret.set("JBSWY3DPEHPK3PXP".into());
+        form.totp_visible = true;
+        form.target_password.set("typed-target".into());
+
+        form.sweep_secrets();
+
+        // Revealed stored plaintext is gone, and still resolves to
+        // "preserve" so the save semantics never changed.
+        assert_eq!(form.password.as_str(), "");
+        assert_eq!(form.password.resolve(), None);
+        assert_eq!(form.proxy_password.as_str(), "");
+        assert_eq!(form.proxy_password.resolve(), None);
+        // Work in progress survives a panel switch untouched.
+        assert_eq!(form.totp_secret.resolve(), Some("JBSWY3DPEHPK3PXP"));
+        assert_eq!(form.target_password.resolve(), Some("typed-target"));
+        // Every eye closes, including the ones over a kept buffer.
+        assert!(!form.password_visible);
+        assert!(!form.proxy_password_visible);
+        assert!(!form.totp_visible);
+        assert!(!form.target_password_visible);
+    }
+
+    /// An edited-empty buffer is an explicit "clear the stored secret",
+    /// which the sweep must not silently downgrade to "preserve".
+    #[test]
+    fn keeps_an_explicit_clear_pending() {
+        let mut form = ConnectionForm::default();
+        form.password.set(String::new());
+        form.sweep_secrets();
+        assert_eq!(form.password.resolve(), Some(""));
     }
 }

--- a/crates/oryxis-app/src/state/modes.rs
+++ b/crates/oryxis-app/src/state/modes.rs
@@ -85,8 +85,6 @@ impl TerminalSidebarTab {
 /// so adding the eye to a new password input is a one-variant change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SecretField {
-    /// Inline proxy password in the host editor.
-    ProxyPassword,
     /// Password on the Share (portable export) dialog.
     SharePassword,
     /// AI assistant API key (Settings > AI).

--- a/crates/oryxis-app/src/views/host_panel/mod.rs
+++ b/crates/oryxis-app/src/views/host_panel/mod.rs
@@ -8,7 +8,7 @@ use iced::{Background, Border, Color, Element, Length, Padding};
 use oryxis_core::models::connection::AuthMethod;
 use oryxis_core::models::identity::Identity;
 
-use crate::app::{SettingsMessage, TabsMessage, EditorMessage, KeysMessage, NavigationMessage, Message, Oryxis};
+use crate::app::{TabsMessage, EditorMessage, KeysMessage, NavigationMessage, Message, Oryxis};
 use crate::i18n::t;
 use crate::state::ProxyKind;
 use crate::theme::OryxisColors;

--- a/crates/oryxis-app/src/views/host_panel/network.rs
+++ b/crates/oryxis-app/src/views/host_panel/network.rs
@@ -654,18 +654,15 @@ impl Oryxis {
                         self.editor_form.proxy_password.as_str(),
                         |v| Message::Editor(EditorMessage::EditorProxyPasswordChanged(v.into())),
                         Some(Message::Editor(EditorMessage::EditorSave)),
-                        self.revealed_secrets
-                            .contains(&crate::state::SecretField::ProxyPassword),
-                        Message::Settings(SettingsMessage::ToggleSecretVisibility(
-                            crate::state::SecretField::ProxyPassword,
-                        )),
+                        self.editor_form.proxy_password_visible,
+                        Message::Editor(EditorMessage::EditorToggleProxyPasswordVisibility),
                         10.0,
                         Some(iced::widget::Id::new("editor-proxy-password")),
                         |eye| self.panel_nav_slot(
                             crate::keynav::RowAction::activate(
-                                Message::Settings(SettingsMessage::ToggleSecretVisibility(
-                                    crate::state::SecretField::ProxyPassword,
-                                )),
+                                Message::Editor(
+                                    EditorMessage::EditorToggleProxyPasswordVisibility,
+                                ),
                             ),
                             6.0,
                             eye,


### PR DESCRIPTION
## Summary

A host's stored password could never be read back. The eye toggle only unmasked what you had just typed, so on a host whose password lives in the vault the field sat empty behind a masked placeholder and clicking the eye showed nothing.

The eye now reveals stored secrets too, Termius-style: it decrypts the stored value on demand and shows it in plaintext, and drops it again when the eye closes or the editor panel is left. Four fields carry an eye and all four behave the same way: the connection password, the TOTP secret, the login-script target password and the inline proxy password.

## How it works

`SecretInput::prefill` seeds the buffer WITHOUT marking it touched, so a revealed-but-unedited field still resolves to `None` on save, which is the vault's "preserve the stored secret". Typing in a revealed field replaces it exactly as typing in an empty one always did, so the tri-state (preserve / replace / clear) is unchanged.

`Oryxis::toggle_editor_secret(EditorSecret)` is the one handler behind all four eyes. Revealing reads the matching vault column, hiding empties the buffer again, and a buffer the user typed into is never overwritten by the reveal nor emptied by the hide: it is their text, not the vault's.

`ConnectionForm::sweep_secrets` is the backstop for the paths that never see a second click. It runs wherever the host editor's panel closes (save, connect-without-saving, cancel, delete, and every right-panel switch: cloud form, discovery, dynamic group, session-group editor, group editor), empties every untouched buffer and closes every eye. Vault lock already replaced the whole form, so it was covered.

The inline proxy password used to ride the app-wide `revealed_secrets` set, which nothing resets when the form is swapped. It is a form flag (`proxy_password_visible`) like the other three now, so opening another host always starts masked instead of leaving the field unmasked and empty behind the "a password is stored" placeholder.

## Secrets

No new crypto path: the same vault getters the connect path uses (`get_connection_password`, `get_proxy_password`, `get_connection_totp_secret`, `get_connection_target_password`), decrypted at use. Opening the editor already read all four to decide whether to show the masked placeholder; what is new is that one of them is now KEPT, for exactly as long as the eye is open.

Because the buffer now holds decrypted vault material, `SecretInput` zeroizes what it displaces and what it drops, and its `Debug` is redacted by hand so a formatted form cannot carry a password into a log line or a panic message. That covers the buffer. The `text_input` it is bound to keeps its own copy of the value to render, which is beyond our reach, so this narrows the exposure rather than closing it.

Revealing is not gated behind the master password. The secret is already reachable through the app that is holding it (it types it at connect time), and this is what Termius, 1Password and every browser password manager do.

## Tests

`cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace --lib --bins` green, with new unit tests for the panel-close sweep (revealed stored plaintext goes, typed input stays, an explicit clear stays pending, every eye closes) and for the redacted `Debug`.

Headless harness: a saved host's password reveals in plaintext on the eye, and reopening the editor after closing it with the eye still open comes back masked.
