### PR TITLE
Join soft-wrapped lines in terminal copy

### DIFF
--- a/crates/oryxis-terminal/src/widget/selection.rs
+++ b/crates/oryxis-terminal/src/widget/selection.rs
@@ -196,6 +196,30 @@ mod selection_tests {
     }
 
     #[test]
+    fn flowing_selection_joins_soft_wrapped_rows() {
+        // A 40-char line at width 20 occupies two physical rows with a
+        // WRAPLINE on row 0's last cell. The copy must join them back into
+        // one logical line (tmux / xterm behaviour), not insert a newline at
+        // the wrap — that is what keeps a long URL intact when selected.
+        let mut state = TerminalState::new_no_pty(20, 6).unwrap();
+        let url = "u".repeat(40);
+        state.process(url.as_bytes());
+        let sel = Selection { start: (0, 0), end: (19, 1), block: false };
+        assert_eq!(state.get_selection_text(&sel), url);
+    }
+
+    #[test]
+    fn flowing_selection_keeps_real_break_after_wrapped_line() {
+        // A wrapped line followed by a genuine CRLF: the wrap joins silently,
+        // but the real line break still copies out as a newline.
+        let mut state = TerminalState::new_no_pty(20, 6).unwrap();
+        let line = format!("{}\r\n", "u".repeat(40));
+        state.process(line.as_bytes());
+        let sel = Selection { start: (0, 0), end: (19, 2), block: false };
+        assert_eq!(state.get_selection_text(&sel), format!("{}\n", "u".repeat(40)));
+    }
+
+    #[test]
     fn flowing_selection_skips_wide_char_spacers() {
         // Each CJK glyph occupies two grid cells: the leading cell holds the
         // character, the trailing cell is a WIDE_CHAR_SPACER whose `c` is a

--- a/crates/oryxis-terminal/src/widget/selection.rs
+++ b/crates/oryxis-terminal/src/widget/selection.rs
@@ -220,6 +220,34 @@ mod selection_tests {
     }
 
     #[test]
+    fn flowing_selection_keeps_spaces_straddling_the_wrap() {
+        // 17 chars plus 3 spaces fill row 0 exactly, so the run of spaces
+        // sits at the wrap boundary and "bcd" continues on row 1. Those
+        // spaces are interior content of the logical line: a wrapped row is
+        // never trimmed (alacritty's `line_length` rule), so the copy must
+        // keep them instead of eating them with the trailing-space trim.
+        let mut state = TerminalState::new_no_pty(20, 6).unwrap();
+        let logical = format!("{}   bcd", "a".repeat(17));
+        state.process(logical.as_bytes());
+        let sel = Selection { start: (0, 0), end: (19, 1), block: false };
+        assert_eq!(state.get_selection_text(&sel), logical);
+    }
+
+    #[test]
+    fn flowing_selection_skips_leading_spacer_at_wrap() {
+        // A wide CJK glyph that doesn't fit in the last column wraps whole:
+        // the row ends in a LEADING_WIDE_CHAR_SPACER ghost cell (which also
+        // carries WRAPLINE). With wrapped rows kept untrimmed, that ghost
+        // must be skipped or it copies out as a stray space inside the
+        // joined line.
+        let mut state = TerminalState::new_no_pty(20, 6).unwrap();
+        let logical = format!("{}你x", "a".repeat(19));
+        state.process(logical.as_bytes());
+        let sel = Selection { start: (0, 0), end: (19, 1), block: false };
+        assert_eq!(state.get_selection_text(&sel), logical);
+    }
+
+    #[test]
     fn flowing_selection_skips_wide_char_spacers() {
         // Each CJK glyph occupies two grid cells: the leading cell holds the
         // character, the trailing cell is a WIDE_CHAR_SPACER whose `c` is a

--- a/crates/oryxis-terminal/src/widget/state.rs
+++ b/crates/oryxis-terminal/src/widget/state.rs
@@ -788,7 +788,8 @@ impl TerminalState {
         // Each row is trimmed of trailing whitespace before joining, the
         // standard terminal behaviour so a wrapped/multi-line copy doesn't
         // carry the blank padding out to the right margin.
-        let mut rows: Vec<String> = Vec::new();
+        let mut text = String::new();
+        let mut prev_line: Option<i32> = None;
         for line_idx in start.1..=end.1 {
             let line = Line(line_idx);
             if line < topmost || line > bottommost {
@@ -819,10 +820,24 @@ impl TerminalState {
                     line_str.push(cell.c);
                 }
             }
-            rows.push(line_str.trim_end().to_string());
+            // A row whose predecessor ended in a soft wrap (WRAPLINE on its
+            // last cell) is the continuation of one logical line, so it joins
+            // WITHOUT a newline — the tmux / xterm behaviour that lets a
+            // wrapped long URL copy out intact. Real line breaks still get
+            // `\n` between the physical rows.
+            if let Some(prev) = prev_line {
+                let wrapped = grid[Line(prev)][Column(last_col as usize)]
+                    .flags
+                    .contains(CellFlags::WRAPLINE);
+                if !wrapped {
+                    text.push('\n');
+                }
+            }
+            prev_line = Some(line_idx);
+            text.push_str(line_str.trim_end());
         }
 
-        rows.join("\n")
+        text
     }
 
     /// Last `n_lines` rows of the terminal buffer as text, **including

--- a/crates/oryxis-terminal/src/widget/state.rs
+++ b/crates/oryxis-terminal/src/widget/state.rs
@@ -814,15 +814,23 @@ impl TerminalState {
             let mut line_str = String::new();
             for c in start_col..=end_col {
                 let cell = &row[Column(c as usize)];
-                // Skip wide-char spacer cells (the trailing half of a CJK
-                // glyph), otherwise each one copies out as an extra space.
-                if cell.c != '\0' && !cell.flags.contains(CellFlags::WIDE_CHAR_SPACER) {
+                // Skip wide-char spacer cells: the trailing half of a CJK
+                // glyph (WIDE_CHAR_SPACER), and the ghost cell left at the
+                // end of a row when a wide char doesn't fit and wraps whole
+                // (LEADING_WIDE_CHAR_SPACER). Either would copy out as a
+                // stray space; the leading one matters now that wrapped rows
+                // keep their tail untrimmed below.
+                if cell.c != '\0'
+                    && !cell.flags.intersects(
+                        CellFlags::WIDE_CHAR_SPACER | CellFlags::LEADING_WIDE_CHAR_SPACER,
+                    )
+                {
                     line_str.push(cell.c);
                 }
             }
             // A row whose predecessor ended in a soft wrap (WRAPLINE on its
             // last cell) is the continuation of one logical line, so it joins
-            // WITHOUT a newline — the tmux / xterm behaviour that lets a
+            // WITHOUT a newline: the tmux / xterm behaviour that lets a
             // wrapped long URL copy out intact. Real line breaks still get
             // `\n` between the physical rows.
             if let Some(prev) = prev_line {
@@ -834,7 +842,19 @@ impl TerminalState {
                 }
             }
             prev_line = Some(line_idx);
-            text.push_str(line_str.trim_end());
+            // A soft-wrapped row is full to the margin, so its trailing cells
+            // are interior content of the logical line (spaces straddling the
+            // wrap point are real). Never trim it, mirroring alacritty's
+            // `Row::line_length`, which reports the full width under
+            // WRAPLINE; only rows that end a logical line get trimmed.
+            let row_wrapped = row[Column(last_col as usize)]
+                .flags
+                .contains(CellFlags::WRAPLINE);
+            if row_wrapped {
+                text.push_str(&line_str);
+            } else {
+                text.push_str(line_str.trim_end());
+            }
         }
 
         text


### PR DESCRIPTION
## Summary

Copying a terminal selection that spans a soft wrap inserted a `\n` at the wrap point, so a long URL (or any long line) came out broken in two. tmux and xterm join soft-wrapped rows back into one logical line; this PR makes Oryxis's terminal behave the same way.

## Root cause

Every copy path (`Ctrl+Shift+C` chord, right-click copy, copy-on-select) funnels through `TerminalState::get_selection_text()`, which joined every physical grid row with `\n` unconditionally. It never consulted the grid's `WRAPLINE` flag, so it could not tell a soft wrap (window-width continuation) apart from a real line break (CRLF written by the program).

## Changes

- `crates/oryxis-terminal/src/widget/state.rs`, flowing-selection branch of `get_selection_text`:
  - When the previously pushed row's last cell carries `WRAPLINE`, the current row is a soft-wrap continuation and joins without a separator; otherwise a `\n` is inserted as before.
  - A row whose own last cell carries `WRAPLINE` is never trimmed (follow-up 2c92e6d): a wrapped row is full to the margin, so its trailing cells are interior content of the logical line, and the unconditional `trim_end()` was eating real spaces that straddle the wrap boundary. Mirrors alacritty's `Row::line_length` rule.
  - The cell loop also skips `LEADING_WIDE_CHAR_SPACER` (follow-up 2c92e6d): the ghost cell left when a wide CJK glyph wraps whole would otherwise leak into the copy as a stray space now that wrapped rows keep their tail (the trim used to mask it by accident).
- Block (rectangular) selections are untouched: each row keeps its own line, preserving column alignment.
- `crates/oryxis-terminal/src/widget/selection.rs`, four new unit tests:
  - `flowing_selection_joins_soft_wrapped_rows`: a 40-char line at width 20 copies as one continuous line.
  - `flowing_selection_keeps_real_break_after_wrapped_line`: a wrap joins silently, while a following real CRLF still copies as `\n`.
  - `flowing_selection_keeps_spaces_straddling_the_wrap`: spaces that fall on the wrap boundary survive the copy.
  - `flowing_selection_skips_leading_spacer_at_wrap`: a wide glyph wrapping whole does not copy out a stray space.

## Testing

`cargo test -p oryxis-terminal` passes (201) and `cargo clippy -p oryxis-terminal --all-targets -- -D warnings` is clean.
