### PR TITLE
fix(window): sync maximized state with the OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -261,7 +261,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2177,7 +2177,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2253,7 +2253,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpi"
 version = "0.1.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 
 [[package]]
 name = "dtor"
@@ -2424,7 +2424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4475,7 +4475,7 @@ dependencies = [
  "mio",
  "nix 0.31.3",
  "serialport",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4484,7 +4484,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4538,7 +4538,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4726,7 +4726,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5587,7 +5587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6294,7 +6294,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6988,7 +6988,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7058,7 +7058,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7692,7 +7692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8020,10 +8020,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8571,7 +8571,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8631,7 +8631,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9355,7 +9355,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9740,7 +9740,7 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 [[package]]
 name = "winit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "bitflags 2.13.1",
  "cfg_aliases 0.2.2",
@@ -9766,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "winit-android"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "android-activity",
  "bitflags 2.13.1",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "winit-appkit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
@@ -9803,7 +9803,7 @@ dependencies = [
 [[package]]
 name = "winit-common"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "block2",
  "memmap2",
@@ -9820,7 +9820,7 @@ dependencies = [
 [[package]]
 name = "winit-core"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "bitflags 2.13.1",
  "cursor-icon",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "winit-orbital"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "bitflags 2.13.1",
  "dpi 0.1.2 (git+https://github.com/wilsonglasser/winit)",
@@ -9851,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "winit-uikit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "winit-wayland"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "bitflags 2.13.1",
  "calloop",
@@ -9898,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "winit-web"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "atomic-waker",
  "bitflags 2.13.1",
@@ -9920,7 +9920,7 @@ dependencies = [
 [[package]]
 name = "winit-win32"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "bitflags 2.13.1",
  "cursor-icon",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "winit-x11"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/wilsonglasser/winit#0d6a8394da306380293b44e26c1afe2c7a523576"
+source = "git+https://github.com/wilsonglasser/winit#e54d023c08c97db20a741bf8a62f82a7bb53aaa2"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",

--- a/crates/oryxis-app/src/app.rs
+++ b/crates/oryxis-app/src/app.rs
@@ -531,8 +531,11 @@ pub struct Oryxis {
     /// not fullscreen). This is what `persist_window_geometry` writes to
     /// the settings table so the next launch restores the floating size
     /// rather than whatever monitor-sized rectangle the window occupied
-    /// at close. Updated by `WindowResized` only while both optimistic
-    /// state flags below are off.
+    /// at close. Committed by `WindowMaximizedSynced` (which carries the
+    /// resize that triggered it) once the OS has confirmed the window is
+    /// not maximized: judging against the optimistic flag in the resize
+    /// handler let an OS-side maximize record its monitor-sized
+    /// rectangle here before the reconcile landed.
     pub(crate) window_windowed_size: iced::Size,
     /// The last outer position the window had while plain-windowed, in
     /// logical desktop coordinates (negative on monitors left of / above
@@ -543,6 +546,13 @@ pub struct Oryxis {
     /// whole session on Wayland, where window positions don't exist, so
     /// nothing is persisted and the next launch uses the WM's placement.
     pub(crate) window_windowed_pos: Option<Point>,
+    /// The value `window_windowed_pos` held before its last write. An
+    /// OS-side maximize (Win+Up, aero snap) parks the window at the
+    /// monitor origin while `window_maximized` is still stale-false, so
+    /// the accompanying `Moved` overwrites the real windowed position;
+    /// the `WindowMaximizedSynced` reconcile rolls back to this slot
+    /// when it detects that drift.
+    pub(crate) window_windowed_pos_prev: Option<Point>,
     /// Whether the OS window currently has focus. Driven by the
     /// `Focused` / `Unfocused` window events. The cloud SSM/ECS
     /// keepalive only ticks while this is `false` (the user alt-tabbed

--- a/crates/oryxis-app/src/app.rs
+++ b/crates/oryxis-app/src/app.rs
@@ -571,9 +571,11 @@ pub struct Oryxis {
     #[cfg(target_os = "windows")]
     pub(crate) last_printscreen: Option<std::time::Instant>,
     /// Whether the OS window is currently maximized. Used by the custom
-    /// chrome to swap the maximize glyph for a "restore" glyph. Toggled
-    /// optimistically on `WindowMaximizeToggle` since our chrome is the only
-    /// path that can change this state (native titlebar is disabled).
+    /// chrome to swap the maximize glyph for a "restore" glyph. Flipped
+    /// optimistically by `WindowMaximizeToggle` and reconciled with the
+    /// OS truth by `WindowMaximizedSynced` after a `WindowResized`
+    /// (Win+Up/Down, aero snap and dragging the custom title bar down
+    /// all change the OS state without firing a toggle message).
     pub(crate) window_maximized: bool,
     /// Whether the window is in native fullscreen mode. Flipped by F11.
     /// Same optimistic pattern as `window_maximized` because the OS-side

--- a/crates/oryxis-app/src/boot/mod.rs
+++ b/crates/oryxis-app/src/boot/mod.rs
@@ -371,6 +371,7 @@ impl Oryxis {
                 window_size: restored_window_size,
                 window_windowed_size: restored_window_size,
                 window_windowed_pos: restored_window_pos,
+                window_windowed_pos_prev: restored_window_pos,
                 window_focused: true,
                 ssm_keepalive_base: None,
                 window_maximized: restored_maximized,

--- a/crates/oryxis-app/src/dispatch_tabs/mod.rs
+++ b/crates/oryxis-app/src/dispatch_tabs/mod.rs
@@ -71,6 +71,7 @@ impl Oryxis {
                 | TabsMessage::WindowExpandVertical
                 | TabsMessage::WindowMinimize
                 | TabsMessage::WindowMaximizeToggle
+                | TabsMessage::WindowMaximizedSynced(..)
                 | TabsMessage::WindowClose
                 | TabsMessage::WindowFullscreenToggle
                 | TabsMessage::FullscreenHintHide

--- a/crates/oryxis-app/src/dispatch_tabs/window.rs
+++ b/crates/oryxis-app/src/dispatch_tabs/window.rs
@@ -164,15 +164,6 @@ impl Oryxis {
             || (snapped.height - self.window_size.height).abs() > 0.5
         {
             self.window_size = snapped;
-            // Track the last plain-windowed size separately: it is
-            // what `persist_window_geometry` restores on the next
-            // launch. The maximize / fullscreen flags flip
-            // optimistically *before* the OS resize arrives, so the
-            // monitor-sized events those transitions emit are
-            // correctly skipped here.
-            if !self.window_maximized && !self.window_fullscreen {
-                self.window_windowed_size = snapped;
-            }
             // The floating toolbar search / overflow popovers are
             // anchored to a width that just changed, and the inline
             // field may now fit again. Dismiss them so they re-pop
@@ -194,12 +185,18 @@ impl Oryxis {
             // `WindowResizeDrag` into a no-op (field report: the
             // window looked windowed but had no edges to grab).
             // `WM_SIZE` has already updated winit's cached state by
-            // the time this event reaches us, so the query returns
-            // the settled truth — no race with our own optimistic
-            // toggle.
-            return iced::window::latest().then(|id_opt| match id_opt {
-                Some(id) => iced::window::is_maximized(id)
-                    .map(|maximized| Message::Tabs(TabsMessage::WindowMaximizedSynced(maximized))),
+            // the time this event reaches us, so the query returns the
+            // settled truth, with no race against our own optimistic
+            // toggle. The snapped size rides along because the
+            // windowed-size tracking (what `persist_window_geometry`
+            // restores next launch) must also be judged against the OS
+            // truth: recording it here, gated on the optimistic flag,
+            // let an OS-side maximize slip its monitor-sized rectangle
+            // in as the "windowed" size before the reconcile landed.
+            return iced::window::latest().then(move |id_opt| match id_opt {
+                Some(id) => iced::window::is_maximized(id).map(move |maximized| {
+                    Message::Tabs(TabsMessage::WindowMaximizedSynced(maximized, snapped))
+                }),
                 None => Task::none(),
             });
         }
@@ -534,6 +531,14 @@ impl Oryxis {
                     && !self.window_fullscreen
                     && !minimized_sentinel
                 {
+                    // Keep the previous value around: an OS-side
+                    // maximize parks the window at the monitor origin
+                    // while `window_maximized` is still stale-false,
+                    // so that Moved passes this guard and overwrites
+                    // the real windowed position. When the
+                    // `WindowMaximizedSynced` reconcile then detects
+                    // the drift, it rolls back to this slot.
+                    self.window_windowed_pos_prev = self.window_windowed_pos;
                     self.window_windowed_pos = Some(pos);
                 }
             }
@@ -564,13 +569,35 @@ impl Oryxis {
             }
             TabsMessage::WindowExpandVertical => return self.handle_window_expand_vertical(),
             TabsMessage::WindowMinimize => return self.handle_window_minimize(),
-            TabsMessage::WindowMaximizedSynced(maximized) => {
+            TabsMessage::WindowMaximizedSynced(maximized, size) => {
+                // Deferred windowed-size commit: `size` is the snapped
+                // size of the `WindowResized` that triggered this
+                // query, recorded only now that the OS has said
+                // whether that rectangle was a real windowed size or a
+                // maximize transition's monitor-sized one. The
+                // fullscreen flag needs no such reconcile: F11 is the
+                // only path that changes it, so the optimistic flip
+                // always lands before the fullscreen resize arrives.
+                if !maximized && !self.window_fullscreen {
+                    self.window_windowed_size = size;
+                }
                 // Reconcile the optimistic flag with the OS truth
-                // (see `WindowMaximizedSynced`). Only touch state when
-                // it actually drifted so the common no-op path stays
-                // cheap.
+                // (see `WindowMaximizedSynced`).
                 if self.window_maximized != maximized {
+                    if maximized {
+                        // OS-side maximize: the Moved that parked the
+                        // window at the monitor origin was recorded
+                        // while the flag was still stale-false. Roll
+                        // the windowed position back to the value it
+                        // overwrote.
+                        self.window_windowed_pos = self.window_windowed_pos_prev;
+                    }
                     self.window_maximized = maximized;
+                    // Same rationale as `WindowMaximizeToggle`: cheap
+                    // write, and it keeps the restored state accurate
+                    // even when the process later dies without
+                    // reaching an exit path (OS shutdown, kill).
+                    self.persist_window_geometry();
                 }
             }
             TabsMessage::WindowMaximizeToggle => {

--- a/crates/oryxis-app/src/dispatch_tabs/window.rs
+++ b/crates/oryxis-app/src/dispatch_tabs/window.rs
@@ -185,6 +185,23 @@ impl Oryxis {
             ) {
                 self.overlay = None;
             }
+            // Reconcile the optimistic `window_maximized` with the OS
+            // truth. Win+Up/Down, aero snap, the taskbar's Restore and
+            // dragging the custom title bar down (a restore inside the
+            // OS move loop, so no app message ever fires) all change
+            // the OS state without `WindowMaximizeToggle`; a stale
+            // `true` would hide the edge-resize border and turn
+            // `WindowResizeDrag` into a no-op (field report: the
+            // window looked windowed but had no edges to grab).
+            // `WM_SIZE` has already updated winit's cached state by
+            // the time this event reaches us, so the query returns
+            // the settled truth — no race with our own optimistic
+            // toggle.
+            return iced::window::latest().then(|id_opt| match id_opt {
+                Some(id) => iced::window::is_maximized(id)
+                    .map(|maximized| Message::Tabs(TabsMessage::WindowMaximizedSynced(maximized))),
+                None => Task::none(),
+            });
         }
         Task::none()
     }
@@ -547,6 +564,15 @@ impl Oryxis {
             }
             TabsMessage::WindowExpandVertical => return self.handle_window_expand_vertical(),
             TabsMessage::WindowMinimize => return self.handle_window_minimize(),
+            TabsMessage::WindowMaximizedSynced(maximized) => {
+                // Reconcile the optimistic flag with the OS truth
+                // (see `WindowMaximizedSynced`). Only touch state when
+                // it actually drifted so the common no-op path stays
+                // cheap.
+                if self.window_maximized != maximized {
+                    self.window_maximized = maximized;
+                }
+            }
             TabsMessage::WindowMaximizeToggle => {
                 self.window_maximized = !self.window_maximized;
                 // Cheap write, and it keeps the restored state accurate

--- a/crates/oryxis-app/src/messages/tabs.rs
+++ b/crates/oryxis-app/src/messages/tabs.rs
@@ -190,6 +190,13 @@ pub enum TabsMessage {
     WindowExpandVertical,
     WindowMinimize,
     WindowMaximizeToggle,
+    /// OS truth about the maximized state, reconciled asynchronously
+    /// after a `WindowResized`. Win+Up/Down, aero snap, the taskbar's
+    /// Restore, and dragging the custom title bar down all change the
+    /// OS state without firing `WindowMaximizeToggle`, so the optimistic
+    /// flag would silently go stale and take the edge-resize border and
+    /// `WindowResizeDrag` down with it.
+    WindowMaximizedSynced(bool),
     WindowFullscreenToggle,
     /// Clears the "Press F11 to exit fullscreen" banner. Fired by a
     /// timed `Task::perform` 3 s after entering fullscreen.

--- a/crates/oryxis-app/src/messages/tabs.rs
+++ b/crates/oryxis-app/src/messages/tabs.rs
@@ -195,8 +195,12 @@ pub enum TabsMessage {
     /// Restore, and dragging the custom title bar down all change the
     /// OS state without firing `WindowMaximizeToggle`, so the optimistic
     /// flag would silently go stale and take the edge-resize border and
-    /// `WindowResizeDrag` down with it.
-    WindowMaximizedSynced(bool),
+    /// `WindowResizeDrag` down with it. Carries the snapped size of the
+    /// `WindowResized` that triggered the query: `window_windowed_size`
+    /// is committed here, once the OS has answered, rather than in the
+    /// resize handler where the stale flag could let a monitor-sized
+    /// rectangle through as the "windowed" size.
+    WindowMaximizedSynced(bool, iced::Size),
     WindowFullscreenToggle,
     /// Clears the "Press F11 to exit fullscreen" banner. Fired by a
     /// timed `Task::perform` 3 s after entering fullscreen.


### PR DESCRIPTION
## Summary

The edge-resize border can silently disappear after an OS-side maximize change. `window_maximized` is flipped optimistically by the app's own `WindowMaximizeToggle` (the custom title bar is the only chrome), but Win+Up/Down, aero snap, the taskbar's Restore and dragging the custom title bar down all change the OS state without firing that message. Repro: maximize with Win+Up, then restore with Win+Down; the border stays hidden and edge drags do nothing until the window is toggled through the app's own chrome.

A stale `true` hides the border entirely (no resize cursor, no edge drag), swaps the maximize glyph for a restore glyph, and persists the wrong maximized state on exit.

## Implementation

- After every `WindowResized` that passes the 8 px debounce, query `iced::window::is_maximized` and reconcile the optimistic flag with the OS truth via a new `TabsMessage::WindowMaximizedSynced(bool, iced::Size)`. `Resized` is the one event every maximize / restore transition emits on all platforms; iced exposes no dedicated `Maximized` window event, and `WM_SIZE` updates winit's state before the event reaches the app, so the query returns the settled truth.
- The windowed-geometry tracking is judged against the same OS truth (follow-up commits on top of the original reconcile): `window_windowed_size` is committed by the sync handler once the OS has confirmed the window is not maximized, so an OS-side maximize can no longer record its monitor-sized rectangle as the "windowed" size; `window_windowed_pos` rolls back through a one-deep prev slot when the reconcile detects drift, undoing the `Moved` that parked the window at the monitor origin.
- Drift also calls `persist_window_geometry()`, for the same reason `WindowMaximizeToggle` persists on every flip: an unclean exit (OS shutdown, kill) keeps the restored state accurate.

## Dependency

The drag itself additionally needed a fix in the winit fork: `handle_os_dragging` posted the synthetic `WM_NCLBUTTONDOWN` with the address of a stack `POINTS` as its coordinate LPARAM instead of the packed cursor coordinates, so `DefWindowProc`'s move/size loop could fail to start. Fixed in wilsonglasser/winit#1 (merged as `e54d023c`) and repinned in `Cargo.lock` here, so this PR delivers the whole fix end to end: border, resize cursor, and the OS drag.

## Testing

- `cargo check -p oryxis-app`, `cargo clippy -p oryxis-app --all-targets -- -D warnings` and the bin tests (759) pass.
- No automated test added: the reconcile exercises the OS window manager, which the headless harness cannot drive (its window actions are no-ops); the manual pass below is the regression guard.
- Manual (Windows, by the PR author, with the winit fix applied locally): Win+Up / Win+Down and title-bar-drag restore no longer hide the border; edge drags resize; the maximize glyph tracks the real state; the persisted maximized flag round-trips correctly. The windowed-geometry follow-up commits are compile / clippy / test gated; their runtime pass rides the next nightly.
