### PR TITLE
fix(harness): sandbox the vault on Windows

### DIFF
--- a/crates/oryxis-app/src/harness/mod.rs
+++ b/crates/oryxis-app/src/harness/mod.rs
@@ -159,6 +159,13 @@ pub fn options_from_args() -> Option<Options> {
         std::env::set_var("HOME", &options.home);
         #[cfg(windows)]
         std::env::set_var("USERPROFILE", &options.home);
+        // `dirs::home_dir()` on Windows is `SHGetKnownFolderPath`
+        // (WinAPI) and ignores `$HOME` / `%USERPROFILE%`, so the
+        // vault would still resolve to the REAL profile. `ORYXIS_HOME`
+        // is the vault-level override `VaultStore::open_default`
+        // honors; point it at the sandbox on every platform so a
+        // harness run can never touch the real ~/.oryxis.
+        std::env::set_var("ORYXIS_HOME", &options.home);
     }
 
     Some(options)

--- a/crates/oryxis-app/src/harness/mod.rs
+++ b/crates/oryxis-app/src/harness/mod.rs
@@ -127,9 +127,13 @@ pub struct Options {
 /// a test tool must never silently mis-run.
 ///
 /// When a mode IS requested, this redirects `$HOME` (and
-/// `%USERPROFILE%` on Windows) to the sandbox before returning, so
-/// every later `dirs::home_dir()` call in the process, the vault,
-/// plugin cache, fonts, logs, resolves inside the sandbox.
+/// `%USERPROFILE%` on Windows) to the sandbox before returning: on
+/// Unix every later `dirs::home_dir()` call in the process (vault,
+/// plugin cache, fonts, logs) resolves inside the sandbox. On Windows
+/// `dirs::home_dir()` is a WinAPI call that ignores both variables,
+/// so the vault is redirected separately through `ORYXIS_HOME`; the
+/// other `~/.oryxis` consumers (plugin cache, fonts, logs, tray
+/// runtime) still resolve to the real profile there, a known gap.
 pub fn options_from_args() -> Option<Options> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let options = match parse(&args) {

--- a/crates/oryxis-vault/src/store/mod.rs
+++ b/crates/oryxis-vault/src/store/mod.rs
@@ -449,8 +449,21 @@ mod tests;
 
 impl VaultStore {
     /// Open or create the vault database at the default location (~/.oryxis/vault.db).
+    ///
+    /// `ORYXIS_HOME` overrides the home directory (the harness sandbox
+    /// relies on it on Windows, where `dirs::home_dir()` is a WinAPI call
+    /// that ignores `$HOME` / `%USERPROFILE%`); without the override the
+    /// harness would read and write the REAL profile vault. An empty value
+    /// is treated as unset, so an accidental `export ORYXIS_HOME=` can
+    /// never land the vault in the process working directory.
     pub fn open_default() -> Result<Self, VaultError> {
-        let dir = dirs::home_dir()
+        let dir = std::env::var_os("ORYXIS_HOME")
+            // An empty export must fall through to the real home, matching
+            // `dirs_sys`' own `HOME` handling; otherwise the vault would
+            // land in `./.oryxis` under the process working directory.
+            .filter(|h| !h.is_empty())
+            .map(PathBuf::from)
+            .or(dirs::home_dir())
             .ok_or_else(|| VaultError::Io(std::io::Error::other("No home directory")))?
             .join(".oryxis");
         std::fs::create_dir_all(&dir)?;

--- a/crates/oryxis-vault/src/store/mod.rs
+++ b/crates/oryxis-vault/src/store/mod.rs
@@ -447,6 +447,24 @@ pub use logs::{SealedSessionOutput, CONTENT_SEARCH_MAX_SCAN_BYTES};
 #[cfg(test)]
 mod tests;
 
+/// Resolves the home directory the vault lives under: the `ORYXIS_HOME`
+/// override when set and non-empty, the OS home otherwise. Split from
+/// [`VaultStore::open_default`] so the resolution is unit-testable
+/// without mutating the process environment (`set_var` is unsafe under
+/// Rust 2024, and the test binary runs its tests on parallel threads).
+fn vault_home(
+    override_home: Option<std::ffi::OsString>,
+    os_home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    override_home
+        // An empty export must fall through to the real home, matching
+        // `dirs_sys`' own `HOME` handling; otherwise the vault would
+        // land in `./.oryxis` under the process working directory.
+        .filter(|h| !h.is_empty())
+        .map(PathBuf::from)
+        .or(os_home)
+}
+
 impl VaultStore {
     /// Open or create the vault database at the default location (~/.oryxis/vault.db).
     ///
@@ -457,13 +475,7 @@ impl VaultStore {
     /// is treated as unset, so an accidental `export ORYXIS_HOME=` can
     /// never land the vault in the process working directory.
     pub fn open_default() -> Result<Self, VaultError> {
-        let dir = std::env::var_os("ORYXIS_HOME")
-            // An empty export must fall through to the real home, matching
-            // `dirs_sys`' own `HOME` handling; otherwise the vault would
-            // land in `./.oryxis` under the process working directory.
-            .filter(|h| !h.is_empty())
-            .map(PathBuf::from)
-            .or(dirs::home_dir())
+        let dir = vault_home(std::env::var_os("ORYXIS_HOME"), dirs::home_dir())
             .ok_or_else(|| VaultError::Io(std::io::Error::other("No home directory")))?
             .join(".oryxis");
         std::fs::create_dir_all(&dir)?;

--- a/crates/oryxis-vault/src/store/tests/mod.rs
+++ b/crates/oryxis-vault/src/store/tests/mod.rs
@@ -42,23 +42,31 @@ mod settings;
 mod snippets;
 mod sync;
 
-/// `ORYXIS_HOME` overrides the vault location. The harness sandbox
-/// depends on this on Windows, where `dirs::home_dir()` is a WinAPI
-/// call that ignores `$HOME` / `%USERPROFILE%` — without the override
-/// a harness run would open (and migrate) the REAL profile's vault.
-/// (The empty-value fallthrough is documented on `open_default`; it is
-/// not testable without opening a real vault, which a unit test must
-/// never do.)
+/// `ORYXIS_HOME` overrides the vault's home directory. The harness
+/// sandbox depends on this on Windows, where `dirs::home_dir()` is a
+/// WinAPI call that ignores `$HOME` / `%USERPROFILE%`: without the
+/// override a harness run would open (and migrate) the REAL profile's
+/// vault. Exercised through the pure resolver because this binary runs
+/// its tests on parallel threads, where `set_var` racing any `getenv`
+/// (`tempfile` reads `TMPDIR` on every tempdir) is undefined behavior;
+/// the end-to-end pin lives in `tests/oryxis_home.rs`, a binary with
+/// exactly one test and therefore no such race.
 #[test]
-fn open_default_honors_oryxis_home() {
-    let dir = tempfile::tempdir().unwrap();
-    let sandbox = dir.path().join(".oryxis");
-    // SAFETY: single-threaded test; no other test in this binary reads
-    // ORYXIS_HOME (grep), so the env mutation cannot race a real-home
-    // open. Edition 2024 makes set_var/remove_var unsafe.
-    unsafe { std::env::set_var("ORYXIS_HOME", dir.path()) };
-    let vault = VaultStore::open_default().unwrap();
-    drop(vault); // release the SQLite handle before asserting
-    assert!(sandbox.join("vault.db").exists());
-    unsafe { std::env::remove_var("ORYXIS_HOME") };
+fn oryxis_home_overrides_vault_home() {
+    use std::ffi::OsString;
+
+    let sandbox = || Some(OsString::from("/sandbox"));
+    let home = || Some(PathBuf::from("/real-home"));
+    // The override wins over the OS home.
+    assert_eq!(
+        super::vault_home(sandbox(), home()),
+        Some(PathBuf::from("/sandbox"))
+    );
+    // Unset: the OS home.
+    assert_eq!(super::vault_home(None, home()), home());
+    // An accidental `export ORYXIS_HOME=` falls through to the real
+    // home instead of landing the vault in the working directory.
+    assert_eq!(super::vault_home(Some(OsString::new()), home()), home());
+    // Nothing resolves at all: `open_default` surfaces an error.
+    assert_eq!(super::vault_home(Some(OsString::new()), None), None);
 }

--- a/crates/oryxis-vault/src/store/tests/mod.rs
+++ b/crates/oryxis-vault/src/store/tests/mod.rs
@@ -41,3 +41,24 @@ mod portable_hardening;
 mod settings;
 mod snippets;
 mod sync;
+
+/// `ORYXIS_HOME` overrides the vault location. The harness sandbox
+/// depends on this on Windows, where `dirs::home_dir()` is a WinAPI
+/// call that ignores `$HOME` / `%USERPROFILE%` — without the override
+/// a harness run would open (and migrate) the REAL profile's vault.
+/// (The empty-value fallthrough is documented on `open_default`; it is
+/// not testable without opening a real vault, which a unit test must
+/// never do.)
+#[test]
+fn open_default_honors_oryxis_home() {
+    let dir = tempfile::tempdir().unwrap();
+    let sandbox = dir.path().join(".oryxis");
+    // SAFETY: single-threaded test; no other test in this binary reads
+    // ORYXIS_HOME (grep), so the env mutation cannot race a real-home
+    // open. Edition 2024 makes set_var/remove_var unsafe.
+    unsafe { std::env::set_var("ORYXIS_HOME", dir.path()) };
+    let vault = VaultStore::open_default().unwrap();
+    drop(vault); // release the SQLite handle before asserting
+    assert!(sandbox.join("vault.db").exists());
+    unsafe { std::env::remove_var("ORYXIS_HOME") };
+}

--- a/crates/oryxis-vault/tests/oryxis_home.rs
+++ b/crates/oryxis-vault/tests/oryxis_home.rs
@@ -1,0 +1,25 @@
+//! End-to-end pin for the `ORYXIS_HOME` vault redirect (the harness
+//! sandbox depends on it on Windows, where `dirs::home_dir()` is a
+//! WinAPI call that ignores `$HOME` / `%USERPROFILE%`).
+//!
+//! This lives in its own integration-test binary on purpose: the
+//! override can only be proven end to end by mutating the process
+//! environment, and under Rust 2024 `set_var` is unsafe because it
+//! races any concurrent `getenv`. A binary with exactly one test has
+//! no other thread to race, which is what makes the call sound here;
+//! the resolution logic itself (override wins, empty means unset) is
+//! unit-tested in the library (`oryxis_home_overrides_vault_home`)
+//! without touching the environment.
+
+use oryxis_vault::VaultStore;
+
+#[test]
+fn open_default_honors_oryxis_home() {
+    let dir = tempfile::tempdir().unwrap();
+    // SAFETY: this binary contains exactly this one test, so no other
+    // thread reads the environment while it is mutated.
+    unsafe { std::env::set_var("ORYXIS_HOME", dir.path()) };
+    let vault = VaultStore::open_default().unwrap();
+    drop(vault); // release the SQLite handle before asserting
+    assert!(dir.path().join(".oryxis").join("vault.db").exists());
+}


### PR DESCRIPTION
## Problem

`dirs::home_dir()` is `SHGetKnownFolderPath` on Windows - a WinAPI call that ignores `$HOME` / `%USERPROFILE%`. The harness sandbox redirects those env vars, so on Windows the vault still resolved to the REAL profile: a harness run would open (and boot-migrate) the user's actual vault instead of the sandbox.

## Fix

- `VaultStore::open_default` now honors an `ORYXIS_HOME` override before falling back to `dirs::home_dir()`. An empty value is treated as unset, so an accidental `export ORYXIS_HOME=` can never land the vault in the process working directory.
- The harness sets `ORYXIS_HOME` to the sandbox on every platform, and its doc now states the platform split honestly: on Windows the other `~/.oryxis` consumers (plugin cache, fonts, logs, tray runtime) still resolve to the real profile - a known gap for a follow-up.
- The resolution lives in a pure `vault_home()` helper: the unit test covers override/unset/empty without mutating the process environment (the test binary runs threaded, where `set_var` racing any `getenv` is UB), and the end-to-end pin `open_default_honors_oryxis_home` lives in its own integration-test binary whose single test has no thread to race.

## Validation

Verified live: the harness daemon's vault now lands in the sandbox (`<home>/.oryxis/vault.db`) and boots into first-run onboarding instead of the real vault's lock screen. `cargo clippy -p oryxis-vault --all-targets` and `cargo test -p oryxis-vault` green, `cargo check -p oryxis-app --features harness` green.