### PR TITLE
Move sync blocking work off the UI thread

### DIFF
--- a/crates/oryxis-app/src/boot/mod.rs
+++ b/crates/oryxis-app/src/boot/mod.rs
@@ -663,6 +663,13 @@ impl Oryxis {
         {
             tasks.push(app.start_sync_engine());
         }
+        // The git card's availability probe spawns a subprocess, so it
+        // runs as a task rather than inside `view()`. Fire it whenever
+        // the git transport can be on screen (also done on `VaultUnlock`
+        // and on `TransportChanged`).
+        if app.vault_ui.state == VaultState::Unlocked && app.sync.transport == "git" {
+            tasks.push(crate::dispatch_git_sync::git_availability_task());
+        }
 
         // Auto-start port forward rules marked `auto_start`. Deferred to
         // `VaultUnlock` when the vault is locked, same as sync / --connect.

--- a/crates/oryxis-app/src/dispatch_folder_sync.rs
+++ b/crates/oryxis-app/src/dispatch_folder_sync.rs
@@ -76,16 +76,14 @@ impl Oryxis {
             self.sync.folder.status = Some(Err(t("sftp_sync_no_passphrase").to_string()));
             return Task::none();
         }
-        let secret = match oryxis_vault::derive_sync_secret(&self.sync.folder.passphrase) {
-            Ok(s) => s,
-            Err(e) => {
-                self.sync.folder.status = Some(Err(e.to_string()));
-                return Task::none();
-            }
-        };
+        // Argon2id derivation (~0.4 s) runs inside the blocking task,
+        // not on the UI thread (same reason as the Git transport).
+        let passphrase = self.sync.folder.passphrase.clone();
         let Some(vault) = &self.vault else {
             return Task::none();
         };
+        // Argon2id derivation (~0.4 s) runs inside the blocking task,
+        // not on the UI thread (same reason as the Git transport).
         let db_path = vault.db_path().to_path_buf();
         let master_password = self.master_password.clone();
 
@@ -116,6 +114,8 @@ impl Oryxis {
         Task::perform(
             async move {
                 tokio::task::spawn_blocking(move || {
+                    let secret = oryxis_vault::derive_sync_secret(&passphrase)
+                        .map_err(|e| e.to_string())?;
                     folder_round(&input, &db_path, master_password, &secret, &device_tag)
                 })
                 .await

--- a/crates/oryxis-app/src/dispatch_git_sync.rs
+++ b/crates/oryxis-app/src/dispatch_git_sync.rs
@@ -98,6 +98,15 @@ fn git(dir: Option<&Path>, args: &[&str]) -> Result<String, String> {
             "GIT_SSH_COMMAND",
             "ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new",
         );
+    // CREATE_NO_WINDOW (0x0800_0000): this binary is GUI-subsystem, so
+    // every `git` spawn would otherwise pop a visible console window
+    // over the app (same guard wsl.exe / the plugin hosts / the
+    // updater use). One flag keeps a whole round from flashing.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt as _;
+        cmd.creation_flags(0x0800_0000);
+    }
     let out = cmd.output().map_err(|e| e.to_string())?;
     if out.status.success() {
         Ok(String::from_utf8_lossy(&out.stdout).into_owned())
@@ -117,6 +126,19 @@ fn git(dir: Option<&Path>, args: &[&str]) -> Result<String, String> {
 /// user is still looking at the setting.
 pub(crate) fn git_available() -> bool {
     git(None, &["--version"]).is_ok()
+}
+
+/// Re-check `git_available` on a worker thread and cache the answer in
+/// `GitSyncForm::git_available`.
+///
+/// The probe must never run inside `view()`: it spawns a subprocess,
+/// so a per-render call blocks the UI thread and (on Windows) flashes
+/// a console window every frame. Boot, a transport switch and each
+/// finished round refresh the cache instead.
+pub(crate) fn git_availability_task() -> Task<Message> {
+    Task::perform(async move { git_available() }, |available| {
+        Message::Sync(SyncMessage::GitAvailabilityChecked(available))
+    })
 }
 
 impl Oryxis {
@@ -139,13 +161,11 @@ impl Oryxis {
             self.sync.git.status = Some(Err(t("sftp_sync_no_passphrase").to_string()));
             return Task::none();
         }
-        let secret = match oryxis_vault::derive_sync_secret(&self.sync.git.passphrase) {
-            Ok(s) => s,
-            Err(e) => {
-                self.sync.git.status = Some(Err(e.to_string()));
-                return Task::none();
-            }
-        };
+        // The Argon2id derivation (~0.4 s) runs inside the blocking
+        // task, not on the UI thread: it used to freeze the app for
+        // every "Sync now" click (the stall watchdog logged GitSyncNow
+        // at ~370 ms per round).
+        let passphrase = self.sync.git.passphrase.clone();
         let Some(vault) = &self.vault else {
             return Task::none();
         };
@@ -158,6 +178,8 @@ impl Oryxis {
         Task::perform(
             async move {
                 tokio::task::spawn_blocking(move || {
+                    let secret =
+                        oryxis_vault::derive_sync_secret(&passphrase).map_err(|e| e.to_string())?;
                     git_round(&remote, &db_path, master_password, &secret, &device)
                 })
                 .await
@@ -239,6 +261,17 @@ fn git_round(
     let branch = current_branch(&dir)?;
     let snapshot_path = dir.join(SNAPSHOT_NAME);
 
+    // Unlocked ONCE, outside the retry loop, like the WebDAV round: the
+    // unlock is an Argon2id derivation tuned to take about a second, and
+    // a rejected push is a reason to re-merge, never a reason to
+    // re-derive the key.
+    let mut vault = VaultStore::open(db_path).map_err(|e| e.to_string())?;
+    match master_password.as_deref() {
+        Some(pw) => vault.unlock(pw).map_err(|e| e.to_string())?,
+        None => vault.open_without_password().map_err(|e| e.to_string())?,
+    }
+    let vault = Arc::new(Mutex::new(vault));
+
     let mut last_err = String::new();
     for attempt in 0..PUSH_ATTEMPTS {
         // Start from whatever the remote has. `reset --hard` is safe
@@ -252,13 +285,6 @@ fn git_round(
         }
         // An empty repository (no commits yet) simply has nothing to
         // merge; the first push creates the branch.
-
-        let mut vault = VaultStore::open(db_path).map_err(|e| e.to_string())?;
-        match master_password.as_deref() {
-            Some(pw) => vault.unlock(pw).map_err(|e| e.to_string())?,
-            None => vault.open_without_password().map_err(|e| e.to_string())?,
-        }
-        let vault = Arc::new(Mutex::new(vault));
 
         let mut pulled = 0usize;
         if snapshot_path.is_file() {

--- a/crates/oryxis-app/src/dispatch_sftp_sync.rs
+++ b/crates/oryxis-app/src/dispatch_sftp_sync.rs
@@ -80,21 +80,18 @@ impl Oryxis {
             self.sync.sftp.status = Some(Err(t("sftp_sync_no_passphrase").to_string()));
             return Task::none();
         }
-        let secret = match oryxis_vault::derive_sync_secret(&self.sync.sftp.passphrase) {
-            Ok(s) => s,
-            Err(e) => {
-                self.sync.sftp.status = Some(Err(e.to_string()));
-                return Task::none();
-            }
+        // Argon2id derivation (~0.4 s) runs on a worker thread inside
+        // the task, not on the UI thread (same reason as the Git
+        // transport).
+        let passphrase = self.sync.sftp.passphrase.clone();
+        let Some(vault) = &self.vault else {
+            return Task::none();
         };
 
         // Round-scoped dedicated vault handle: the snapshot fns need an
         // `Arc<Mutex<VaultStore>>` but the app holds a plain handle. Same
         // pattern as `sync_runtime`; opened inside the task on the same
         // SQLite file (WAL makes concurrent handles safe).
-        let Some(vault) = &self.vault else {
-            return Task::none();
-        };
         let db_path = vault.db_path().to_path_buf();
         let master_password = self.master_password.clone();
 
@@ -156,6 +153,14 @@ impl Oryxis {
 
         Task::perform(
             async move {
+                // The group-secret derivation first: Argon2id, off the
+                // UI thread (it used to run synchronously in the
+                // handler, freezing the app for every round).
+                let secret = tokio::task::spawn_blocking(move || {
+                    oryxis_vault::derive_sync_secret(&passphrase).map_err(|e| e.to_string())
+                })
+                .await
+                .unwrap_or_else(|e| Err(format!("join: {e}")))?;
                 // 1. Obtain an SFTP client: reuse an open session, else a
                 //    fresh SFTP-only connect with a STRICT host-key check
                 //    (no ask channel -> the engine rejects unknown/changed

--- a/crates/oryxis-app/src/dispatch_sync.rs
+++ b/crates/oryxis-app/src/dispatch_sync.rs
@@ -396,7 +396,40 @@ impl Oryxis {
                 // clears it there, so the Cancel button stays visible
                 // until the cancellation actually settles.
             }
+            SyncMessage::EngineSpawned => {
+                let Some(mut rx) = self.sync.pending_engine.take() else {
+                    // `stop_sync_engine` abandoned the spawn: its oneshot
+                    // receiver disappeared, the task's `send` failed and
+                    // the fresh runtime dropped (stopping the engine's
+                    // background tasks). Nothing to adopt.
+                    return Task::none();
+                };
+                match rx.try_recv() {
+                    Ok(Ok((runtime, event_rx))) => {
+                        self.sync.runtime = Some(runtime);
+                        self.sync.engine_running = true;
+                        self.sync.status = Some(crate::i18n::t("sync_status_running").to_string());
+                        let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(event_rx);
+                        return Task::stream(stream)
+                            .map(|v| Message::Sync(SyncMessage::EngineEvent(v)));
+                    }
+                    Ok(Err(e)) => {
+                        self.sync.engine_running = false;
+                        self.sync.status =
+                            Some(format!("{}: {e}", crate::i18n::t("sync_status_failed"),));
+                        tracing::warn!("sync engine failed to start: {e}");
+                        return Task::none();
+                    }
+                    Err(_) => {
+                        // The spawn task panicked before sending; there
+                        // is nothing to adopt and `engine_running` was
+                        // never set.
+                        return Task::none();
+                    }
+                }
+            }
             SyncMessage::TransportChanged(v) => {
+                let mut tasks = Vec::new();
                 if v != self.sync.transport {
                     // Leaving P2P: tear the engine down so QUIC/mDNS stop.
                     // Entering P2P (and enabled): bring it up.
@@ -417,9 +450,24 @@ impl Oryxis {
                     if !self.sync_uses_p2p() {
                         self.stop_sync_engine();
                     } else if self.sync.enabled {
-                        return self.start_sync_engine();
+                        tasks.push(self.start_sync_engine());
                     }
                 }
+                // The git card's availability probe is a subprocess
+                // spawn: run it off the UI thread (see
+                // `dispatch_git_sync::git_availability_task`), whenever
+                // the git card can be on screen.
+                if self.sync.transport == "git" {
+                    tasks.push(crate::dispatch_git_sync::git_availability_task());
+                }
+                return if tasks.is_empty() {
+                    Task::none()
+                } else {
+                    Task::batch(tasks)
+                };
+            }
+            SyncMessage::GitAvailabilityChecked(available) => {
+                self.sync.git.git_available = Some(available);
             }
             SyncMessage::SftpHostChanged(id) => {
                 self.sync.sftp.host_id = Some(id);
@@ -502,6 +550,10 @@ impl Oryxis {
             SyncMessage::GitRoundFinished(result) => {
                 self.sync.git.in_progress = false;
                 if result.is_ok() {
+                    // A completed round proves `git` is on PATH; keep
+                    // the card's cached probe current without re-spawning
+                    // on every frame.
+                    self.sync.git.git_available = Some(true);
                     // The round merged on its OWN `VaultStore` handle,
                     // so every in-memory list is stale: whatever it
                     // pulled is on disk and invisible until this

--- a/crates/oryxis-app/src/dispatch_vault/open.rs
+++ b/crates/oryxis-app/src/dispatch_vault/open.rs
@@ -131,6 +131,14 @@ impl Oryxis {
                             // vault (and its credentials) is open.
                             let mut unlock_tasks = vec![sync_task];
                             unlock_tasks.extend(self.auto_start_port_forwards());
+                            // The git card's availability probe spawns a
+                            // subprocess, so it runs as a task (never in
+                            // `view()`). Same probe the boot path and
+                            // `TransportChanged` fire.
+                            if self.sync.transport == "git" {
+                                unlock_tasks
+                                    .push(crate::dispatch_git_sync::git_availability_task());
+                            }
                             // Plugin migrate-install + auto-update: for a
                             // password vault these are deferred from boot
                             // to here, now that the plugin rows are loaded

--- a/crates/oryxis-app/src/dispatch_webdav_sync.rs
+++ b/crates/oryxis-app/src/dispatch_webdav_sync.rs
@@ -108,16 +108,14 @@ impl Oryxis {
             self.sync.webdav.status = Some(Err(t("sftp_sync_no_passphrase").to_string()));
             return Task::none();
         }
-        let secret = match oryxis_vault::derive_sync_secret(&self.sync.webdav.passphrase) {
-            Ok(s) => s,
-            Err(e) => {
-                self.sync.webdav.status = Some(Err(e.to_string()));
-                return Task::none();
-            }
-        };
+        // Argon2id derivation (~0.4 s) runs on a worker thread, not on
+        // the UI thread (same reason as the Git transport).
+        let passphrase = self.sync.webdav.passphrase.clone();
         let Some(vault) = &self.vault else {
             return Task::none();
         };
+        // Argon2id derivation (~0.4 s) runs on a worker thread, not on
+        // the UI thread (same reason as the Git transport).
         let db_path = vault.db_path().to_path_buf();
         let master_password = self.master_password.clone();
         let auth = Auth {
@@ -128,7 +126,14 @@ impl Oryxis {
         self.sync.webdav.in_progress = true;
         self.sync.webdav.status = None;
         Task::perform(
-            async move { webdav_round(&url, &auth, &db_path, master_password, &secret).await },
+            async move {
+                let secret = tokio::task::spawn_blocking(move || {
+                    oryxis_vault::derive_sync_secret(&passphrase).map_err(|e| e.to_string())
+                })
+                .await
+                .unwrap_or_else(|e| Err(format!("join: {e}")))?;
+                webdav_round(&url, &auth, &db_path, master_password, &secret).await
+            },
             |result| Message::Sync(SyncMessage::WebdavRoundFinished(result)),
         )
     }

--- a/crates/oryxis-app/src/messages/sync.rs
+++ b/crates/oryxis-app/src/messages/sync.rs
@@ -48,6 +48,11 @@ pub enum SyncMessage {
     GitPassphraseChanged(super::Redacted),
     /// "Sync now" for the Git transport.
     GitSyncNow,
+    /// Result of the off-thread `git --version` probe, cached in
+    /// `GitSyncForm::git_available` for the card. The probe used to run
+    /// inside `view()`, which froze the UI and flashed a console window
+    /// per render on Windows.
+    GitAvailabilityChecked(bool),
     ToggleEnabled,
     TogglePasswords,
     ModeChanged(String),
@@ -78,6 +83,11 @@ pub enum SyncMessage {
     /// sync completed, pairing progress, ...), pumped in from the
     /// engine's event channel via `Task::stream`.
     EngineEvent(oryxis_sync::SyncEvent),
+    /// The off-thread engine spawn (`start_sync_engine`) finished; its
+    /// outcome is waiting in `SyncState::pending_engine`. The runtime
+    /// and its event receiver aren't Clone, so they cross the task
+    /// boundary through a oneshot instead of a message payload.
+    EngineSpawned,
     /// Stop hosting the pairing code and return to the idle pairing view.
     CancelHostingPairing,
     /// Switch the pairing panel into "join with a code" mode.
@@ -104,9 +114,11 @@ pub enum SyncMessage {
     /// task is racing against; the task lands back as
     /// `SyncNowFinished(Err("Cancelled"))` and clears the flags.
     CancelInProgress,
-    /// Switch the sync transport between `"p2p"` and `"sftp"`. Persists
-    /// the setting, stops the P2P engine when leaving `p2p`, and starts
-    /// it when returning.
+    /// Switch the sync transport ("p2p", "sftp", "folder", "git",
+    /// "webdav"). Persists the setting, stops the P2P engine when
+    /// leaving `p2p`, and starts it when returning. Entering `git` also
+    /// re-probes `git` availability off the UI thread (see
+    /// `dispatch_git_sync::git_availability_task`).
     TransportChanged(String),
     /// Pick the host the SFTP-sync snapshot file lives on (also closes
     /// the picker modal).

--- a/crates/oryxis-app/src/state/forms.rs
+++ b/crates/oryxis-app/src/state/forms.rs
@@ -630,6 +630,13 @@ pub(crate) struct GitSyncForm {
     pub passphrase: String,
     pub in_progress: bool,
     pub status: Option<Result<String, String>>,
+    /// Whether a usable `git` is on PATH. `None` = probe in flight (boot
+    /// or a transport switch resolves it within a moment); the card
+    /// disables "Sync now" until it is known. Probed on a worker thread
+    /// ONLY: the old per-render `git_available()` call inside `view()`
+    /// spawned a subprocess on the UI thread, freezing the app and
+    /// flashing a console window per call on Windows.
+    pub git_available: Option<bool>,
 }
 
 /// WebDAV sync transport: the snapshot on a Nextcloud / ownCloud /

--- a/crates/oryxis-app/src/state/sync.rs
+++ b/crates/oryxis-app/src/state/sync.rs
@@ -43,6 +43,14 @@ pub(crate) struct SyncState {
     /// Live P2P sync engine, present only while sync is enabled. Holds a
     /// dedicated vault handle plus the QUIC / mDNS background tasks.
     pub(crate) runtime: Option<SyncRuntime>,
+    /// One-shot receiver for an in-flight off-thread engine spawn.
+    /// `Some` only between `start_sync_engine()` firing the task and
+    /// the `SyncMessage::EngineSpawned` landing. `stop_sync_engine`
+    /// drops it to abandon a spawn whose engine is still coming up
+    /// (the task's `send` then fails and the fresh runtime drops,
+    /// stopping the engine's background tasks).
+    pub(crate) pending_engine:
+        Option<oneshot::Receiver<crate::sync_runtime::EngineSpawnResult>>,
     /// Mirrors `runtime.is_some()` for cheap UI checks.
     pub(crate) engine_running: bool,
     /// Transient device-pairing UI (hosted code / link, join inputs, and which
@@ -185,6 +193,7 @@ impl Default for SyncState {
             peers: Vec::new(),
             status: None,
             runtime: None,
+            pending_engine: None,
             engine_running: false,
             pairing: SyncPairingForm::default(),
             discovered: Vec::new(),

--- a/crates/oryxis-app/src/sync_runtime.rs
+++ b/crates/oryxis-app/src/sync_runtime.rs
@@ -29,6 +29,13 @@ pub(crate) struct SyncRuntime {
     handle: SyncHandle,
 }
 
+/// Result of an off-thread engine spawn: the runtime plus its event
+/// stream, or the failure. Neither the runtime nor the receiver is
+/// `Clone`, so this crosses the task boundary through a oneshot rather
+/// than riding a message payload.
+pub(crate) type EngineSpawnResult =
+    Result<(SyncRuntime, mpsc::UnboundedReceiver<SyncEvent>), SyncError>;
+
 impl SyncRuntime {
     /// Open a dedicated vault handle, build the engine, start its
     /// background tasks, and hand back the event receiver so the caller
@@ -37,33 +44,49 @@ impl SyncRuntime {
     /// `master_password` is `Some` when the vault has a user password
     /// (we unlock the second handle with it) and `None` when the vault
     /// auto-opens without one (mirrors the boot path in `boot.rs`).
-    pub(crate) fn spawn(
+    ///
+    /// Must be awaited on the Tokio runtime (`start()` calls
+    /// `tokio::spawn`). The expensive half — SQLite open, the Argon2id
+    /// unlock (deliberately tuned to ~1s) and the device identity — runs
+    /// on a blocking thread: this used to run synchronously on the UI
+    /// thread, freezing the app for the whole derivation every time the
+    /// engine started (transport switch, boot, vault unlock).
+    pub(crate) async fn spawn(
         config: SyncConfig,
-        device_name: &str,
-        db_path: &std::path::Path,
-        master_password: Option<&str>,
+        device_name: String,
+        db_path: std::path::PathBuf,
+        master_password: Option<String>,
     ) -> Result<(Self, mpsc::UnboundedReceiver<SyncEvent>), SyncError> {
         // Dedicated handle on the same SQLite file as the app's vault.
-        let mut vault = VaultStore::open(db_path)
-            .map_err(|e| SyncError::Vault(format!("open sync vault handle: {e}")))?;
-        match master_password {
-            Some(pw) => vault
-                .unlock(pw)
-                .map_err(|e| SyncError::Vault(format!("unlock sync vault handle: {e}")))?,
-            None => vault
-                .open_without_password()
-                .map_err(|e| SyncError::Vault(format!("open sync vault handle: {e}")))?,
-        }
+        let (vault, identity) = tokio::task::spawn_blocking(move || {
+            let mut vault = VaultStore::open(&db_path)
+                .map_err(|e| SyncError::Vault(format!("open sync vault handle: {e}")))?;
+            match master_password.as_deref() {
+                Some(pw) => vault
+                    .unlock(pw)
+                    .map_err(|e| SyncError::Vault(format!("unlock sync vault handle: {e}")))?,
+                None => vault
+                    .open_without_password()
+                    .map_err(|e| SyncError::Vault(format!("open sync vault handle: {e}")))?,
+            }
+            // Persistent device identity, generated + stored on first run.
+            let identity = DeviceIdentity::load_or_generate(&vault, &device_name)?;
+            Ok::<_, SyncError>((Arc::new(Mutex::new(vault)), identity))
+        })
+        .await
+        .map_err(|e| SyncError::Vault(format!("join: {e}")))??;
 
-        // Persistent device identity, generated + stored on first run.
-        let identity = DeviceIdentity::load_or_generate(&vault, device_name)?;
-
-        let vault = Arc::new(Mutex::new(vault));
         let mut engine = SyncEngine::new(config, identity, vault);
         let event_rx = engine
             .take_events()
             .expect("a freshly created engine always has its event receiver");
-        engine.start()?;
+        if let Err(e) = engine.start() {
+            // A partial `start()` (QUIC up, mDNS not) leaves spawned
+            // tasks running; stop them before reporting the failure so a
+            // quick toggle off/on can't stack engines.
+            engine.stop();
+            return Err(e);
+        }
         let handle = engine.handle();
 
         Ok((Self { engine, handle }, event_rx))
@@ -158,12 +181,14 @@ impl Oryxis {
         self.vault_ui.state == crate::state::VaultState::Unlocked
     }
 
-    /// Spawn the sync engine from current settings and return a `Task`
-    /// that pumps its event stream into `|v| Message::Sync(SyncMessage::EngineEvent(v))`.
-    /// No-op (`Task::none`) if the engine is already running or the
-    /// vault isn't available.
+    /// Spawn the sync engine from current settings, off the UI thread.
+    /// Returns a `Task` that resolves to `SyncMessage::EngineSpawned`
+    /// when the spawn finishes; that handler stores the runtime and
+    /// returns the `Task::stream` pumping `EngineEvent`s. No-op
+    /// (`Task::none`) if the engine is already running (or a spawn is
+    /// in flight) or the vault isn't available.
     pub(crate) fn start_sync_engine(&mut self) -> Task<Message> {
-        if self.sync.runtime.is_some() {
+        if self.sync.runtime.is_some() || self.sync.pending_engine.is_some() {
             return Task::none();
         }
         let Some(vault) = &self.vault else {
@@ -178,29 +203,34 @@ impl Oryxis {
         };
         let master_password = self.master_password.clone();
 
-        match SyncRuntime::spawn(config, &device_name, &db_path, master_password.as_deref()) {
-            Ok((runtime, event_rx)) => {
-                self.sync.runtime = Some(runtime);
-                self.sync.engine_running = true;
-                self.sync.status = Some(crate::i18n::t("sync_status_running").to_string());
-                let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(event_rx);
-                Task::stream(stream).map(|v| Message::Sync(SyncMessage::EngineEvent(v)))
-            }
-            Err(e) => {
-                self.sync.engine_running = false;
-                self.sync.status =
-                    Some(format!("{}: {e}", crate::i18n::t("sync_status_failed")));
-                tracing::warn!("sync engine failed to start: {e}");
-                Task::none()
-            }
-        }
+        // The spawn unlocks the vault (Argon2id, ~1s) and binds QUIC /
+        // mDNS; it must not run on the UI thread (it used to, and
+        // selecting P2P froze the app for the whole derivation). The
+        // runtime and its event receiver aren't Clone, so they come
+        // back through a oneshot and a signal message; the handler
+        // stores the runtime and pumps the event stream.
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.sync.pending_engine = Some(rx);
+        Task::perform(
+            async move {
+                let result =
+                    SyncRuntime::spawn(config, device_name, db_path, master_password).await;
+                let _ = tx.send(result);
+                Message::Sync(SyncMessage::EngineSpawned)
+            },
+            |msg| msg,
+        )
     }
 
-    /// Stop the sync engine if it is running. Idempotent.
+    /// Stop the sync engine if it is running. Idempotent. Also drops a
+    /// pending spawn: its oneshot receiver disappears, the spawn task's
+    /// `send` fails, and the just-built runtime drops, which stops the
+    /// engine's background tasks.
     pub(crate) fn stop_sync_engine(&mut self) {
         if let Some(mut runtime) = self.sync.runtime.take() {
             runtime.stop();
         }
+        self.sync.pending_engine = None;
         self.sync.engine_running = false;
     }
 }

--- a/crates/oryxis-app/src/views/settings/sync.rs
+++ b/crates/oryxis-app/src/views/settings/sync.rs
@@ -433,12 +433,18 @@ impl Oryxis {
     /// Git-transport config: the remote, the group passphrase, and the
     /// one requirement this transport has that no other does.
     ///
-    /// The `git` check runs here rather than at the first sync, so a
-    /// machine without it says so while the user is still choosing,
-    /// instead of after they have typed a URL and pressed a button.
+    /// The `git` check used to run here (in `view()`) so a machine
+    /// without it said so while the user was still choosing. That froze
+    /// the UI and flashed a console window per render on Windows (a
+    /// subprocess spawn on the UI thread). It now runs as a task
+    /// (`GitAvailabilityChecked`) at boot, on transport switch and after
+    /// each round; this card only reads the cached result.
     fn sync_git_card(&self) -> Element<'_, Message> {
         let busy = self.sync.git.in_progress;
-        let has_git = crate::dispatch_git_sync::git_available();
+        // `None` = probe in flight: the button waits a moment rather
+        // than guessing, and no warning is shown until the probe
+        // answers.
+        let has_git = self.sync.git.git_available.unwrap_or(false);
         let mut col = column![
             text(t("git_sync_desc"))
                 .size(11)
@@ -446,7 +452,7 @@ impl Oryxis {
             Space::new().height(10),
         ];
 
-        if !has_git {
+        if self.sync.git.git_available == Some(false) {
             col = col
                 .push(
                     text(t("git_sync_no_git"))


### PR DESCRIPTION
**Problem.** The sync feature blocked the UI thread in three places, each visible as a freeze:

1. **Git card freeze + console flashes (Windows).** The Git transport's availability probe (`git --version`) ran inside `view()` — a subprocess spawn on every render. On Windows each spawn also popped a console window over the app.
2. **P2P engine start stall.** `start_sync_engine()` ran the whole spawn synchronously on the UI thread, including the Argon2id vault unlock. The stall watchdog logged `UPDATE STALLED for 2214 ms ... Sync(TransportChanged("p2p"))` — up to 10 s per switch.
3. **Per-round Argon2id stall.** Every "Sync now" click derived the snapshot key (`derive_sync_secret`, ~370 ms) in the click handler — Git, SFTP, Folder and WebDAV alike.

**Fix.** Blocking work now runs off the UI thread; behavior is unchanged:

- The Git availability probe is cached in `GitSyncForm.git_available` and refreshed by a `Task::perform` at boot, on transport switch, and after each finished round. The card only reads the cache.
- `git` subprocesses set `CREATE_NO_WINDOW` on Windows (same guard as the wsl.exe / plugin / updater spawns).
- The P2P engine spawn moved into `Task::perform`: vault unlock and device-identity generation run on `spawn_blocking`; engine construction and `start()` stay on the runtime (`tokio::spawn` requires it). The non-Clone runtime and event receiver come back via a oneshot plus `SyncMessage::EngineSpawned`. `stop_sync_engine` drops a pending spawn so a quick toggle cannot stack engines.
- `derive_sync_secret` moved inside the blocking task of all four snapshot transports.
- The vault unlock was hoisted out of the git round's push-retry loop (a rejected push is a reason to re-merge, not to re-derive the key).

**Validation.** `cargo test --workspace --lib --bins` is green; a harness E2E run (fresh vault, local bare remote: sync → restart → unlock → sync) succeeds with no stalls.
