### PR TITLE
fix(keynav): settings fields keep Tab and arrows

### DIFF
--- a/crates/oryxis-app/src/dispatch_keynav.rs
+++ b/crates/oryxis-app/src/dispatch_keynav.rs
@@ -17,7 +17,7 @@ use iced::keyboard;
 use iced::Task;
 
 use crate::app::{SettingsMessage, TabsMessage, EditorMessage, KeysMessage, SshMessage, CloudMessage, HistoryMessage, NavigationMessage, ProxyIdentityMessage, KnownHostMessage, SessionGroupMessage, PortForwardMessage, SnippetMessage, DashNavItem, Message, Oryxis};
-use crate::keynav::movement::{cycle_zone, grid_move, linear_move, MoveKey};
+use crate::keynav::movement::{cycle_zone, grid_move, index_move, linear_move, MoveKey};
 use crate::keynav::{FocusZone, NavItem, ToolbarItem};
 use crate::state::View;
 
@@ -100,7 +100,22 @@ impl Oryxis {
             ))));
         }
         match named {
-            Named::Tab => Some(self.keynav_cycle_zones(!modifiers.shift())),
+            Named::Tab => {
+                // Settings content, ring idle: a mouse-focused text input
+                // (the export / import password, the sync passphrase, the
+                // auto-lock field) owns its keys. Resolve what iced
+                // actually has focused, then walk the recorded rows from
+                // that field (the panel contract: inputs get real focus,
+                // the rest ring) instead of parking the ring on the FIRST
+                // content row — the Security section's "Vault Password"
+                // toggle — and scrolling the page away mid-typing. The
+                // fall-through keeps the zone cycle (Tab from the search
+                // field enters Content at its first row).
+                if let Some(task) = self.settings_ring_idle_resolve(*named, modifiers.shift()) {
+                    return Some(task);
+                }
+                Some(self.keynav_cycle_zones(!modifiers.shift()))
+            }
             // Desktop convention: the Menu key (and Shift+F10) opens
             // the selected item's context menu.
             Named::ContextMenu => self.keynav_open_context_menu(),
@@ -127,6 +142,12 @@ impl Oryxis {
                     // Shift+arrow is text selection in the search
                     // field; never ours.
                     return None;
+                }
+                // Same mouse-focused-field rule as Tab above: while the
+                // ring is idle in Settings the arrow belongs to the
+                // input's own caret, not to Content-entry at row 0.
+                if let Some(task) = self.settings_ring_idle_resolve(*named, modifiers.shift()) {
+                    return Some(task);
                 }
                 self.keynav_move(*named)
             }
@@ -884,5 +905,108 @@ impl Oryxis {
             scroll_id,
             iced::widget::operation::RelativeOffset { x: None, y: Some(y) },
         )
+    }
+
+    /// Settings content, ring idle: hand a Tab / movement key to
+    /// [`Self::settings_key_resolved`] once iced reports what it
+    /// actually has focused (resolved via `find_focused`). Returns
+    /// `Some(task)` when the Settings-keeps-its-keys rule applies (a
+    /// mouse-focused input row walks the recorded rows on Tab and keeps
+    /// its own caret on arrows); `None` leaves the normal vault-area
+    /// handling to run. Called from the router's Tab and movement arms,
+    /// whose surrounding gates (`side_panel_open`, modals, the Security
+    /// password forms, modifiers) have already run.
+    fn settings_ring_idle_resolve(
+        &self,
+        named: keyboard::key::Named,
+        shift: bool,
+    ) -> Option<Task<Message>> {
+        if !(self.active_tab.is_none()
+            && self.active_view == View::Settings
+            && self.keynav.focus.is_none())
+        {
+            return None;
+        }
+        Some(iced::widget::operation::find_focused().map(move |focused| {
+            Message::Navigation(NavigationMessage::SettingsKeyResolved {
+                named,
+                shift,
+                focused,
+            })
+        }))
+    }
+
+    /// Continuation of a Settings-content Tab / arrow press once iced
+    /// has reported which widget is actually focused (the gate in
+    /// `handle_keynav_key` resolves it via `find_focused`). A
+    /// mouse-focused input row owns the walk: Tab / Shift+Tab step
+    /// through the recorded rows from that field (the panel contract),
+    /// arrows / Home / End stay with the field's own caret. Anything
+    /// else gets the key the vault-area router would have given it:
+    /// Tab cycles the zones, arrows enter the content zone.
+    pub(crate) fn settings_key_resolved(
+        &mut self,
+        named: keyboard::key::Named,
+        shift: bool,
+        focused: Option<iced::widget::Id>,
+    ) -> Task<Message> {
+        use keyboard::key::Named as N;
+        let row = focused.and_then(|id| {
+            self.keynav
+                .settings_row_actions
+                .borrow()
+                .iter()
+                .position(|a| a.focus.as_ref() == Some(&id))
+        });
+        match (named, row) {
+            (N::Tab, Some(from)) => self.settings_nav_tab(!shift, from),
+            (N::Tab, None) => self.keynav_cycle_zones(!shift),
+            // A focused input row: the field's own caret / selection
+            // handling owns every non-Tab key (the panel contract).
+            (_, Some(_)) => Task::none(),
+            _ => self.settings_key_unclaimed(named),
+        }
+    }
+
+    /// Tab / Shift+Tab over the recorded Settings rows, entering at the
+    /// row whose input iced currently has focused (`from`). Input rows
+    /// receive real iced focus; the rest get the ring and iced focus is
+    /// blurred — the panel contract, applied to the Settings content so
+    /// a mouse-focused field (the export / import password, the sync
+    /// passphrase) Tabs onward instead of the vault-area router parking
+    /// the ring on the first content row and scrolling the page away.
+    fn settings_nav_tab(&mut self, forward: bool, from: usize) -> Task<Message> {
+        let len = self.keynav.settings_row_actions.borrow().len();
+        let Some(next) = index_move(len, Some(from), forward) else {
+            return Task::none();
+        };
+        let action = self.keynav.settings_row_actions.borrow().get(next).cloned();
+        let Some(action) = action else {
+            return Task::none();
+        };
+        self.keynav.focus = Some((FocusZone::Content, NavItem::SettingsRow(next)));
+        let step = match action.focus {
+            Some(id) => crate::widgets::focus_input(id),
+            None => blur_task(),
+        };
+        Task::batch([step, self.keynav_scroll_content_to(NavItem::SettingsRow(next))])
+    }
+
+    /// The vault-area handling a Settings-content key would have had
+    /// when no mouse-focused input row is in play: arrows / Home / End
+    /// move within the content zone from idle (Tab is handled inline by
+    /// `settings_key_resolved`). Mirrors the arms of `handle_keynav_key`
+    /// the resolution in `settings_ring_idle_resolve` intercepted.
+    fn settings_key_unclaimed(&mut self, named: keyboard::key::Named) -> Task<Message> {
+        use keyboard::key::Named as N;
+        match named {
+            N::ArrowUp
+            | N::ArrowDown
+            | N::ArrowLeft
+            | N::ArrowRight
+            | N::Home
+            | N::End => self.keynav_move(named).unwrap_or(Task::none()),
+            _ => Task::none(),
+        }
     }
 }

--- a/crates/oryxis-app/src/dispatch_navigation.rs
+++ b/crates/oryxis-app/src/dispatch_navigation.rs
@@ -36,6 +36,13 @@ impl Oryxis {
             NavigationMessage::PanelNavTabResolved { forward, focused } => {
                 return self.panel_nav_tab_resolved(forward, focused);
             }
+            NavigationMessage::SettingsKeyResolved {
+                named,
+                shift,
+                focused,
+            } => {
+                return self.settings_key_resolved(named, shift, focused);
+            }
             // -- Navigation --
             NavigationMessage::GoHome => {
                 // The Home tab lands on the vault surface the user left,

--- a/crates/oryxis-app/src/messages/navigation.rs
+++ b/crates/oryxis-app/src/messages/navigation.rs
@@ -24,6 +24,21 @@ pub enum NavigationMessage {
         forward: bool,
         focused: Option<iced::widget::Id>,
     },
+    /// Continuation of a Settings-content Tab / arrow press with no
+    /// keynav ring active: `focused` is the widget iced actually has
+    /// focused (resolved via `find_focused`), so a mouse-focused field
+    /// (the export / import password, the sync passphrase) can walk the
+    /// recorded rows on Tab instead of the vault-area router parking
+    /// the ring on the first content row and scrolling the page away;
+    /// arrows / Home / End stay with the field's own caret. `None` =
+    /// nothing focused (fall back to the normal router).
+    SettingsKeyResolved {
+        /// The intercepted named key (Tab or a movement key).
+        named: iced::keyboard::key::Named,
+        /// Shift held: Shift+Tab walks the rows backward.
+        shift: bool,
+        focused: Option<iced::widget::Id>,
+    },
     /// Dashboard: open/close the host tag-filter dropdown.
     ShowHostTagFilterMenu,
     /// Dashboard: toggle one tag in the multi-select filter (the

--- a/crates/oryxis-app/tests/e2e/settings-password-tab-walk.ice
+++ b/crates/oryxis-app/tests/e2e/settings-password-tab-walk.ice
@@ -1,0 +1,51 @@
+viewport: 1400x1100
+mode: Zen
+-----
+# Issue: Tab (or arrows) from a MOUSE-focused Settings field must walk
+# the recorded rows (the panel contract), not park the keynav ring on
+# the first content row — the Security section's "Vault Password"
+# toggle — and scroll the page away. Regressed as: type in the export
+# password, press Tab, and the ring lands on the dialog's reveal eye,
+# so Enter toggles the eye instead of flipping the master-password
+# switch (which would open the "Set Password" form). The sync
+# passphrase field (set-sync-sftp-passphrase) has the same problem.
+expect "Welcome to Oryxis"
+click "Skip"
+click "Continue without password"
+settle
+# Through the burger menu rather than the toolbar gear, so the flow
+# doesn't depend on the gear's pixel position at this viewport width.
+click (19, 20)
+settle
+click "Settings"
+settle
+expect "Security & Privacy"
+click "Security & Privacy"
+settle
+expect "Export Vault"
+click "Export Vault"
+settle
+# Mouse-focus the export password field (the path the bug needs) and
+# type a digit.
+click #set-export-password
+settle
+type "2"
+settle
+# Tab must walk to the dialog's eye; Enter toggles the reveal. If the
+# ring had jumped to the Vault Password toggle (the bug), Enter would
+# have opened the set-password form instead.
+type tab
+type enter
+settle
+absent "Set Password"
+expect "Export Vault"
+# Arrows stay native while a mouse-focused field owns the keyboard:
+# no ring jump, so Enter still cannot reach the Vault Password toggle.
+click #set-export-password
+settle
+type down
+settle
+type enter
+settle
+absent "Set Password"
+expect "Export Vault"


### PR DESCRIPTION
## Problem

Reported repro: while entering the export password (Security & Privacy
> Import & Export > Export Vault), typing the digit 2 makes the field's
highlight jump to the "Vault Password" row at the top of the section,
with the page scrolling there; the field also loses keyboard focus, so
further keystrokes go nowhere and the user has to click back into it to
continue typing. Other digits were not affected. Consistently
reproducible in the pre-fix build.

The same happens in the sync passphrase field: the character is entered
while the highlight jumps away to the section's first row and the field
loses focus.

## Root cause

The keynav ring (the accent highlight) is engaged by navigation keys
(Tab / arrow / Home / End). When the router enters the content zone
from the idle state it parks the ring on the FIRST recorded row - the
Security section's "Vault Password" toggle - scrolls the section to
bring that row into view (`keynav_scroll_content_to`) and blurs iced
focus (the zone-entry blur), so further keystrokes go nowhere until
the user clicks back into the field. A click also clears the ring. The
vault-area router cannot tell that a text input holds iced focus (a
mouse click moves focus without touching the ring state), so the
navigation key parks the ring on the first row instead of walking from
the focused field.

## Fix

When the ring is idle in Settings, resolve the actually-focused widget
via `find_focused()` (the same pattern the side-panel layer uses for
its Tab walk), then:

- **Tab / Shift+Tab** walk the recorded rows from the focused field
  (the panel contract: input rows get real iced focus, the rest get
  the ring) - the export password Tabs to its reveal eye, then the
  category checkboxes, instead of jumping to the Vault Password row.
- **arrows / Home / End** stay with the field's own caret.
- Everything else (the settings search field focused, or nothing
  focused) falls through to the normal router, so Tab from the search
  still enters the content zone at its first row.

## Testing

Developer-verified:
- `cargo check --workspace` and `cargo test --workspace --lib --bins`
  pass (769 app tests).
- Headless harness (pixel-checked): with the fix, Tab from the export
  password lands the ring on the dialog's reveal eye and Enter toggles
  the eye instead of opening the "Set Password" form; an arrow press
  leaves the ring idle so the field keeps its caret; the settings
  search field's Tab-into-content behavior is unchanged.
- Adds e2e regression test `settings-password-tab-walk.ice` covering
  the Tab walk and the native-arrow paths (the flow was driven through
  the harness in English; the committed e2e suite runs in the
  English-locale CI).

Reporter-verified:
- The pre-fix build reproduced the reported symptom every time; the
  fixed build accepts the keystroke without the highlight jumping to
  the Vault Password row and without losing the field's focus.