### PR TITLE
fix(tabs): scope PTY key gate per connecting tab

### DIFF
--- a/crates/oryxis-app/src/dispatch_serial.rs
+++ b/crates/oryxis-app/src/dispatch_serial.rs
@@ -119,7 +119,7 @@ impl Oryxis {
                     }
                     Err(e) => {
                         let _ = sender
-                            .send(Message::Ssh(SshMessage::SshError(format!("Serial {path}: {e}"))))
+                            .send(Message::Ssh(SshMessage::SshError(pane_id, format!("Serial {path}: {e}"))))
                             .await;
                     }
                 }

--- a/crates/oryxis-app/src/dispatch_ssh/connect.rs
+++ b/crates/oryxis-app/src/dispatch_ssh/connect.rs
@@ -892,7 +892,7 @@ impl Oryxis {
                     self.tab_scroll_to_active(),
                     Task::stream(stream).map(move |msg| match msg {
                         SshStreamMsg::Progress(step, log) => {
-                            Message::Ssh(SshMessage::SshProgress(step, log))
+                            Message::Ssh(SshMessage::SshProgress(pane_id, step, log))
                         }
                         SshStreamMsg::Connected(session) => Message::Ssh(SshMessage::SshConnected(
                             pane_id,
@@ -913,8 +913,8 @@ impl Oryxis {
                         SshStreamMsg::Data(data) => {
                             Message::Terminal(TerminalMessage::PtyOutput(pane_id, data))
                         }
-                        SshStreamMsg::Banner(text) => Message::Ssh(SshMessage::SshBanner(text)),
-                        SshStreamMsg::Error(err) => Message::Ssh(SshMessage::SshError(err)),
+                        SshStreamMsg::Banner(text) => Message::Ssh(SshMessage::SshBanner(pane_id, text)),
+                        SshStreamMsg::Error(err) => Message::Ssh(SshMessage::SshError(pane_id, err)),
                         SshStreamMsg::NoCommonAlgo { category, server_offers } => {
                             Message::Ssh(SshMessage::SshNoCommonAlgo {
                                 conn_id: map_conn_id,

--- a/crates/oryxis-app/src/dispatch_ssh/errors.rs
+++ b/crates/oryxis-app/src/dispatch_ssh/errors.rs
@@ -74,14 +74,16 @@ impl Oryxis {
                 }
                 tracing::error!("pane SSH connect failed: {msg}");
             }
-            SshMessage::SshError(err) => {
+            SshMessage::SshError(pane_id, err) => {
                 // A cancel provoked by the identity / key switch: retry with
                 // the mutated entry instead of surfacing the failure. The
                 // guard on the progress origin keeps an (unlikely) stale flag
-                // from hijacking an unrelated connect's error.
+                // from hijacking an unrelated connect's error; the pane id
+                // scopes it to the dial this error actually belongs to.
                 if let Some(qid) = self.pending_auth_switch
                     && self.connecting.as_ref().is_some_and(|p| {
                         p.origin == crate::state::ProgressOrigin::Quick(qid)
+                            && p.pane_id == pane_id
                     })
                 {
                     self.pending_auth_switch = None;
@@ -97,9 +99,16 @@ impl Oryxis {
                     return Task::none();
                 }
                 tracing::error!("SSH error: {}", err);
+                // History entry keyed by the pane's own tab label, not the
+                // current progress card's: with concurrent connections the
+                // card may be tracking a different dial than this error.
+                let pane_label = self
+                    .pane_tab_index(pane_id)
+                    .and_then(|i| self.tabs.get(i))
+                    .map(|t| t.label.clone());
                 if self.should_record_history()
                     && let Some(vault) = &self.vault {
-                    let label = self.connecting.as_ref().map(|p| p.label.as_str()).unwrap_or("unknown");
+                    let label = pane_label.as_deref().unwrap_or("unknown");
                     let entry = oryxis_core::models::log_entry::LogEntry::new(
                         label, label, oryxis_core::models::log_entry::LogEvent::Error, &err,
                     );
@@ -111,10 +120,9 @@ impl Oryxis {
                 // identity was never added to the OS agent. Append the
                 // localized hint so the fix is one line away.
                 let err = {
-                    let sk_pinned = self
-                        .connecting
+                    let sk_pinned = pane_label
                         .as_ref()
-                        .and_then(|p| self.any_connection_by_label(&p.label))
+                        .and_then(|l| self.any_connection_by_label(l))
                         .and_then(|c| {
                             c.key_id.or_else(|| {
                                 c.identity_id.and_then(|iid| {
@@ -133,24 +141,45 @@ impl Oryxis {
                         err
                     }
                 };
-                // Mark progress as failed (keep the view open with logs)
-                if let Some(ref mut progress) = self.connecting {
-                    progress.failed = true;
-                    progress.logs.push((progress.step, format!("Error: {}", err)));
-                    // The connect is dead, so a KBI modal parked on it is an
-                    // orphan: its oneshot is gone (submits would vanish
-                    // silently) and the progress card's KBI branch renders
-                    // OVER the failure timeline, hiding the real error
-                    // (blanket auth timeout with the 2FA form open). Drop it
-                    // and answer any waiting bridge.
-                    if self.pending_kbi_prompt.is_some() {
-                        self.pending_kbi_prompt = None;
-                        self.pending_kbi_quick = None;
-                        self.kbi_inputs.clear();
-                        if let Some(ref tx) = self.kbi_response_tx {
-                            let _ = tx.try_send(None);
+                // Mark the progress card failed ONLY when it is tracking
+                // this pane's dial. A later tab's connect may have taken
+                // over the card while this dial was still in flight; in
+                // that case the failure belongs to the pane itself, so
+                // surface it there instead.
+                if self
+                    .connecting
+                    .as_ref()
+                    .is_some_and(|p| p.pane_id == pane_id)
+                {
+                    if let Some(ref mut progress) = self.connecting {
+                        progress.failed = true;
+                        progress.logs.push((progress.step, format!("Error: {}", err)));
+                        // The connect is dead, so a KBI modal parked on it is an
+                        // orphan: its oneshot is gone (submits would vanish
+                        // silently) and the progress card's KBI branch renders
+                        // OVER the failure timeline, hiding the real error
+                        // (blanket auth timeout with the 2FA form open). Drop it
+                        // and answer any waiting bridge.
+                        if self.pending_kbi_prompt.is_some() {
+                            self.pending_kbi_prompt = None;
+                            self.pending_kbi_quick = None;
+                            self.kbi_inputs.clear();
+                            if let Some(ref tx) = self.kbi_response_tx {
+                                let _ = tx.try_send(None);
+                            }
                         }
                     }
+                } else if let Some(pane) = self
+                    .tabs
+                    .iter()
+                    .flat_map(|t| t.pane_grid.panes.values())
+                    .find(|p| p.id == pane_id)
+                    && let Ok(mut state) = pane.terminal.lock()
+                {
+                    // Concurrent-connect fallback: no card tracks this
+                    // dial anymore, so print the failure into the pane's
+                    // own terminal (mirrors `PaneConnectError`).
+                    state.process(format!("\r\nConnection failed: {err}\r\n").as_bytes());
                 } else {
                     self.host_panel_error = Some(format!("SSH: {}", err));
                 }

--- a/crates/oryxis-app/src/dispatch_ssh/progress.rs
+++ b/crates/oryxis-app/src/dispatch_ssh/progress.rs
@@ -10,8 +10,17 @@ use super::*;
 impl Oryxis {
     pub(super) fn handle_ssh_progress(&mut self, message: SshMessage) -> Task<Message> {
         match message {
-            SshMessage::SshProgress(step, log) => {
-                if let Some(ref mut progress) = self.connecting {
+            SshMessage::SshProgress(pane_id, step, log) => {
+                // Scoped to the dial this card is tracking: a progress
+                // event from a connect whose card was superseded by a
+                // newer tab's dial must not append to that card's
+                // timeline (concurrent connections).
+                if self
+                    .connecting
+                    .as_ref()
+                    .is_some_and(|p| p.pane_id == pane_id)
+                    && let Some(ref mut progress) = self.connecting
+                {
                     progress.step = step;
                     progress.logs.push((step, log));
                 }
@@ -115,7 +124,7 @@ impl Oryxis {
                     };
                 }
             }
-            SshMessage::SshBanner(text) => {
+            SshMessage::SshBanner(pane_id, text) => {
                 // Progress-card copy, so legal notices / MFA instructions
                 // are readable while the auth prompts are up. Multiple
                 // banners concatenate, but CAPPED: banners are
@@ -129,7 +138,15 @@ impl Oryxis {
                 if text.trim().is_empty() {
                     return Task::none();
                 }
-                if let Some(p) = &mut self.connecting {
+                // Card copy scoped to the dial this card tracks: a banner
+                // from a connect whose card a newer tab's dial superseded
+                // must not render on that connect's card.
+                if self
+                    .connecting
+                    .as_ref()
+                    .is_some_and(|p| p.pane_id == pane_id)
+                    && let Some(p) = &mut self.connecting
+                {
                     let slot = p.banner.get_or_insert_with(String::new);
                     if slot.len() < BANNER_CAP {
                         if !slot.is_empty() {
@@ -146,10 +163,13 @@ impl Oryxis {
                         }
                     }
                 }
-                // Terminal copy: lands in scrollback, so the banner is
-                // still reviewable after the card closes (PuTTY prints
-                // it in the terminal). The emulator wants CRLF.
-                if let Some(tab_idx) = self.connecting.as_ref().map(|p| p.tab_idx)
+                // Terminal copy: lands in THIS pane's own tab's
+                // scrollback (not the current progress card's tab, which
+                // concurrent connections may have taken over), so the
+                // banner is still reviewable after the card closes
+                // (PuTTY prints it in the terminal). The emulator wants
+                // CRLF.
+                if let Some(tab_idx) = self.pane_tab_index(pane_id)
                     && let Some(tab) = self.tabs.get(tab_idx)
                     && let Ok(mut state) = tab.active().terminal.lock()
                 {

--- a/crates/oryxis-app/src/dispatch_telnet.rs
+++ b/crates/oryxis-app/src/dispatch_telnet.rs
@@ -195,10 +195,13 @@ impl Oryxis {
                     }
                     Err(e) => {
                         let _ = sender
-                            .send(Message::Ssh(SshMessage::SshError(format!(
-                                "Connection to {}:{} failed: {}",
-                                conn_host, conn_port, e
-                            ))))
+                            .send(Message::Ssh(SshMessage::SshError(
+                                pane_id,
+                                format!(
+                                    "Connection to {}:{} failed: {}",
+                                    conn_host, conn_port, e
+                                ),
+                            )))
                             .await;
                     }
                 }

--- a/crates/oryxis-app/src/dispatch_terminal/keyboard.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/keyboard.rs
@@ -366,8 +366,19 @@ impl Oryxis {
                     return Ok(Task::none());
                 }
 
+                // The connect screen covers only the connecting tab (the
+                // render side scopes it via `cp.tab_idx == active_tab` in
+                // `view_content`); match that here. The old app-global
+                // `connecting.is_none()` gate ate every keystroke in every
+                // other tab as long as one tab sat on an in-flight or
+                // failed-and-not-dismissed connect, so typing died until
+                // the connecting tab was closed.
+                let connecting_here = self
+                    .connecting
+                    .as_ref()
+                    .is_some_and(|cp| Some(cp.tab_idx) == self.active_tab);
                 if let Some(tab_idx) = self.active_tab
-                    && self.connecting.is_none()
+                    && !connecting_here
                     && let keyboard::Event::KeyPressed {
                         key,
                         modified_key,

--- a/crates/oryxis-app/src/dispatch_terminal/mod.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/mod.rs
@@ -737,8 +737,16 @@ impl Oryxis {
                 if self.cursor_over_sidebar() {
                     return Task::none();
                 }
+                // Same per-tab scoping as the KeyboardEvent PTY gate: the
+                // connect screen covers only its own tab, so a tab switched
+                // away from an in-flight / failed connect keeps its IME
+                // commits (the old app-global `connecting.is_none()` ate
+                // them until the connecting tab was closed).
                 if let Some(tab_idx) = self.active_tab
-                    && self.connecting.is_none()
+                    && !self
+                        .connecting
+                        .as_ref()
+                        .is_some_and(|cp| Some(cp.tab_idx) == self.active_tab)
                 {
                     let bytes = text.into_bytes();
                     self.write_input_to_tab(tab_idx, &bytes);

--- a/crates/oryxis-app/src/messages/ssh.rs
+++ b/crates/oryxis-app/src/messages/ssh.rs
@@ -22,10 +22,14 @@ pub enum SshMessage {
     /// Protocol badge picked on the quick-connect card (issue #174),
     /// for the case where the typed text names no `scheme://`.
     QuickConnectProtocolPicked(oryxis_core::models::connection::ConnectionProtocol),
-    SshProgress(ConnectionStep, String),
+    /// Progress step for the dial of `(pane_id)`. The pane id is part of
+    /// the message so a later, unrelated connect can't capture an earlier
+    /// dial's timeline on its progress card (concurrent tabs).
+    SshProgress(Uuid, ConnectionStep, String),
     /// Pre-auth banner (RFC 4252 §5.4) for the connect in progress:
-    /// shown on the progress card and written to the tab's terminal.
-    SshBanner(String),
+    /// `(pane_id, text)`; shown on the progress card (when it is tracking
+    /// this pane's dial) and written to that pane's tab terminal.
+    SshBanner(Uuid, String),
     /// Pre-auth banner for a split-pane connect (no progress card):
     /// written straight to that pane's terminal.
     SshPaneBanner(Uuid, String),
@@ -39,7 +43,11 @@ pub enum SshMessage {
     ReuseFailedDialFresh(Uuid),
 
     SshDisconnected(Uuid),  // (pane_id)
-    SshError(String),
+    /// A tab-connect dial failed: `(pane_id, error)`. The pane id lets the
+    /// error land on the progress card that is actually tracking this dial;
+    /// a failure for a dial whose card was superseded by a newer connect
+    /// falls back to writing into that pane's terminal instead.
+    SshError(Uuid, String),
     /// Handshake hit "no common algorithm". Prompts the legacy-fallback
     /// dialog for `conn_id` (the failed category + what the server offered).
     SshNoCommonAlgo {


### PR DESCRIPTION
## Problem
While any tab is mid-connect — or sitting on a failed, not-yet-dismissed connect screen — every other tab's terminal stops accepting keyboard input. Typing in other SSH/Telnet/Serial panes goes nowhere until the connecting tab is closed.

## Root cause
The PTY key-routing gate in `dispatch_terminal` used a single app-global `connecting.is_none()` check. The connect screen only ever covers the connecting tab, but the gate applied to all tabs, so one in-flight/failed connect swallowed keystrokes everywhere.

## Fix
Scope the gate per tab: keystrokes are intercepted only while the *active* tab is the one connecting. The render side already scoped the connect screen via `cp.tab_idx == active_tab`; the keyboard side now matches it. The identical global gate on the IME commit path (`TerminalImeCommit`) gets the same scoping.

As part of this, `SshProgress`/`SshError`/`SshBanner` now carry a `pane_id` so connect events route to the pane that owns them — a second tab connecting no longer displaces the first tab's error card, and a superseded pane's terminal gets the error written into its own buffer.

## Validation
- `cargo check -p oryxis-app --offline` ✓ (branch alone, after splitting)
- `cargo test -p oryxis-app --offline` — 845 passed on the combined working tree that includes this change ✓