### PR TITLE
feat(ime): inline preedit at the caret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5447,6 +5447,7 @@ dependencies = [
  "regex",
  "tokio",
  "tracing",
+ "unicode-width",
  "vte",
  "windows-sys 0.61.2",
 ]

--- a/crates/oryxis-app/src/dispatch_serial.rs
+++ b/crates/oryxis-app/src/dispatch_serial.rs
@@ -119,7 +119,7 @@ impl Oryxis {
                     }
                     Err(e) => {
                         let _ = sender
-                            .send(Message::Ssh(SshMessage::SshError(format!("Serial {path}: {e}"))))
+                            .send(Message::Ssh(SshMessage::SshError(pane_id, format!("Serial {path}: {e}"))))
                             .await;
                     }
                 }

--- a/crates/oryxis-app/src/dispatch_ssh/connect.rs
+++ b/crates/oryxis-app/src/dispatch_ssh/connect.rs
@@ -892,7 +892,7 @@ impl Oryxis {
                     self.tab_scroll_to_active(),
                     Task::stream(stream).map(move |msg| match msg {
                         SshStreamMsg::Progress(step, log) => {
-                            Message::Ssh(SshMessage::SshProgress(step, log))
+                            Message::Ssh(SshMessage::SshProgress(pane_id, step, log))
                         }
                         SshStreamMsg::Connected(session) => Message::Ssh(SshMessage::SshConnected(
                             pane_id,
@@ -913,8 +913,8 @@ impl Oryxis {
                         SshStreamMsg::Data(data) => {
                             Message::Terminal(TerminalMessage::PtyOutput(pane_id, data))
                         }
-                        SshStreamMsg::Banner(text) => Message::Ssh(SshMessage::SshBanner(text)),
-                        SshStreamMsg::Error(err) => Message::Ssh(SshMessage::SshError(err)),
+                        SshStreamMsg::Banner(text) => Message::Ssh(SshMessage::SshBanner(pane_id, text)),
+                        SshStreamMsg::Error(err) => Message::Ssh(SshMessage::SshError(pane_id, err)),
                         SshStreamMsg::NoCommonAlgo { category, server_offers } => {
                             Message::Ssh(SshMessage::SshNoCommonAlgo {
                                 conn_id: map_conn_id,

--- a/crates/oryxis-app/src/dispatch_ssh/errors.rs
+++ b/crates/oryxis-app/src/dispatch_ssh/errors.rs
@@ -74,14 +74,16 @@ impl Oryxis {
                 }
                 tracing::error!("pane SSH connect failed: {msg}");
             }
-            SshMessage::SshError(err) => {
+            SshMessage::SshError(pane_id, err) => {
                 // A cancel provoked by the identity / key switch: retry with
                 // the mutated entry instead of surfacing the failure. The
                 // guard on the progress origin keeps an (unlikely) stale flag
-                // from hijacking an unrelated connect's error.
+                // from hijacking an unrelated connect's error; the pane id
+                // scopes it to the dial this error actually belongs to.
                 if let Some(qid) = self.pending_auth_switch
                     && self.connecting.as_ref().is_some_and(|p| {
                         p.origin == crate::state::ProgressOrigin::Quick(qid)
+                            && p.pane_id == pane_id
                     })
                 {
                     self.pending_auth_switch = None;
@@ -97,9 +99,16 @@ impl Oryxis {
                     return Task::none();
                 }
                 tracing::error!("SSH error: {}", err);
+                // History entry keyed by the pane's own tab label, not the
+                // current progress card's: with concurrent connections the
+                // card may be tracking a different dial than this error.
+                let pane_label = self
+                    .pane_tab_index(pane_id)
+                    .and_then(|i| self.tabs.get(i))
+                    .map(|t| t.label.clone());
                 if self.should_record_history()
                     && let Some(vault) = &self.vault {
-                    let label = self.connecting.as_ref().map(|p| p.label.as_str()).unwrap_or("unknown");
+                    let label = pane_label.as_deref().unwrap_or("unknown");
                     let entry = oryxis_core::models::log_entry::LogEntry::new(
                         label, label, oryxis_core::models::log_entry::LogEvent::Error, &err,
                     );
@@ -111,10 +120,9 @@ impl Oryxis {
                 // identity was never added to the OS agent. Append the
                 // localized hint so the fix is one line away.
                 let err = {
-                    let sk_pinned = self
-                        .connecting
+                    let sk_pinned = pane_label
                         .as_ref()
-                        .and_then(|p| self.any_connection_by_label(&p.label))
+                        .and_then(|l| self.any_connection_by_label(l))
                         .and_then(|c| {
                             c.key_id.or_else(|| {
                                 c.identity_id.and_then(|iid| {
@@ -133,24 +141,45 @@ impl Oryxis {
                         err
                     }
                 };
-                // Mark progress as failed (keep the view open with logs)
-                if let Some(ref mut progress) = self.connecting {
-                    progress.failed = true;
-                    progress.logs.push((progress.step, format!("Error: {}", err)));
-                    // The connect is dead, so a KBI modal parked on it is an
-                    // orphan: its oneshot is gone (submits would vanish
-                    // silently) and the progress card's KBI branch renders
-                    // OVER the failure timeline, hiding the real error
-                    // (blanket auth timeout with the 2FA form open). Drop it
-                    // and answer any waiting bridge.
-                    if self.pending_kbi_prompt.is_some() {
-                        self.pending_kbi_prompt = None;
-                        self.pending_kbi_quick = None;
-                        self.kbi_inputs.clear();
-                        if let Some(ref tx) = self.kbi_response_tx {
-                            let _ = tx.try_send(None);
+                // Mark the progress card failed ONLY when it is tracking
+                // this pane's dial. A later tab's connect may have taken
+                // over the card while this dial was still in flight; in
+                // that case the failure belongs to the pane itself, so
+                // surface it there instead.
+                if self
+                    .connecting
+                    .as_ref()
+                    .is_some_and(|p| p.pane_id == pane_id)
+                {
+                    if let Some(ref mut progress) = self.connecting {
+                        progress.failed = true;
+                        progress.logs.push((progress.step, format!("Error: {}", err)));
+                        // The connect is dead, so a KBI modal parked on it is an
+                        // orphan: its oneshot is gone (submits would vanish
+                        // silently) and the progress card's KBI branch renders
+                        // OVER the failure timeline, hiding the real error
+                        // (blanket auth timeout with the 2FA form open). Drop it
+                        // and answer any waiting bridge.
+                        if self.pending_kbi_prompt.is_some() {
+                            self.pending_kbi_prompt = None;
+                            self.pending_kbi_quick = None;
+                            self.kbi_inputs.clear();
+                            if let Some(ref tx) = self.kbi_response_tx {
+                                let _ = tx.try_send(None);
+                            }
                         }
                     }
+                } else if let Some(pane) = self
+                    .tabs
+                    .iter()
+                    .flat_map(|t| t.pane_grid.panes.values())
+                    .find(|p| p.id == pane_id)
+                    && let Ok(mut state) = pane.terminal.lock()
+                {
+                    // Concurrent-connect fallback: no card tracks this
+                    // dial anymore, so print the failure into the pane's
+                    // own terminal (mirrors `PaneConnectError`).
+                    state.process(format!("\r\nConnection failed: {err}\r\n").as_bytes());
                 } else {
                     self.host_panel_error = Some(format!("SSH: {}", err));
                 }

--- a/crates/oryxis-app/src/dispatch_ssh/progress.rs
+++ b/crates/oryxis-app/src/dispatch_ssh/progress.rs
@@ -10,8 +10,17 @@ use super::*;
 impl Oryxis {
     pub(super) fn handle_ssh_progress(&mut self, message: SshMessage) -> Task<Message> {
         match message {
-            SshMessage::SshProgress(step, log) => {
-                if let Some(ref mut progress) = self.connecting {
+            SshMessage::SshProgress(pane_id, step, log) => {
+                // Scoped to the dial this card is tracking: a progress
+                // event from a connect whose card was superseded by a
+                // newer tab's dial must not append to that card's
+                // timeline (concurrent connections).
+                if self
+                    .connecting
+                    .as_ref()
+                    .is_some_and(|p| p.pane_id == pane_id)
+                    && let Some(ref mut progress) = self.connecting
+                {
                     progress.step = step;
                     progress.logs.push((step, log));
                 }
@@ -115,7 +124,7 @@ impl Oryxis {
                     };
                 }
             }
-            SshMessage::SshBanner(text) => {
+            SshMessage::SshBanner(pane_id, text) => {
                 // Progress-card copy, so legal notices / MFA instructions
                 // are readable while the auth prompts are up. Multiple
                 // banners concatenate, but CAPPED: banners are
@@ -129,7 +138,15 @@ impl Oryxis {
                 if text.trim().is_empty() {
                     return Task::none();
                 }
-                if let Some(p) = &mut self.connecting {
+                // Card copy scoped to the dial this card tracks: a banner
+                // from a connect whose card a newer tab's dial superseded
+                // must not render on that connect's card.
+                if self
+                    .connecting
+                    .as_ref()
+                    .is_some_and(|p| p.pane_id == pane_id)
+                    && let Some(p) = &mut self.connecting
+                {
                     let slot = p.banner.get_or_insert_with(String::new);
                     if slot.len() < BANNER_CAP {
                         if !slot.is_empty() {
@@ -146,10 +163,13 @@ impl Oryxis {
                         }
                     }
                 }
-                // Terminal copy: lands in scrollback, so the banner is
-                // still reviewable after the card closes (PuTTY prints
-                // it in the terminal). The emulator wants CRLF.
-                if let Some(tab_idx) = self.connecting.as_ref().map(|p| p.tab_idx)
+                // Terminal copy: lands in THIS pane's own tab's
+                // scrollback (not the current progress card's tab, which
+                // concurrent connections may have taken over), so the
+                // banner is still reviewable after the card closes
+                // (PuTTY prints it in the terminal). The emulator wants
+                // CRLF.
+                if let Some(tab_idx) = self.pane_tab_index(pane_id)
                     && let Some(tab) = self.tabs.get(tab_idx)
                     && let Ok(mut state) = tab.active().terminal.lock()
                 {

--- a/crates/oryxis-app/src/dispatch_tabs/lifecycle.rs
+++ b/crates/oryxis-app/src/dispatch_tabs/lifecycle.rs
@@ -21,6 +21,15 @@ impl Oryxis {
             // Switching tabs dismisses the session-group editor (it's
             // tied to the tab it was opened from).
             self.panels.session_group_panel = false;
+            // Leaving a tab mid-composition clears its preedit so a stale
+            // IME overlay can't re-show when the user tabs back.
+            if let Some(old_idx) = self.active_tab
+                && old_idx != idx
+                && let Some(old) = self.tabs.get(old_idx)
+                && let Ok(mut state) = old.active().terminal.lock()
+            {
+                state.set_preedit(String::new());
+            }
             self.active_tab = Some(idx);
             // A hybrid tab in Files mode owns the live SFTP buffer
             // while shown (park/hoist, same invariant as the

--- a/crates/oryxis-app/src/dispatch_telnet.rs
+++ b/crates/oryxis-app/src/dispatch_telnet.rs
@@ -195,10 +195,13 @@ impl Oryxis {
                     }
                     Err(e) => {
                         let _ = sender
-                            .send(Message::Ssh(SshMessage::SshError(format!(
-                                "Connection to {}:{} failed: {}",
-                                conn_host, conn_port, e
-                            ))))
+                            .send(Message::Ssh(SshMessage::SshError(
+                                pane_id,
+                                format!(
+                                    "Connection to {}:{} failed: {}",
+                                    conn_host, conn_port, e
+                                ),
+                            )))
                             .await;
                     }
                 }

--- a/crates/oryxis-app/src/dispatch_terminal/keyboard.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/keyboard.rs
@@ -366,8 +366,19 @@ impl Oryxis {
                     return Ok(Task::none());
                 }
 
+                // The connect screen covers only the connecting tab (the
+                // render side scopes it via `cp.tab_idx == active_tab` in
+                // `view_content`); match that here. The old app-global
+                // `connecting.is_none()` gate ate every keystroke in every
+                // other tab as long as one tab sat on an in-flight or
+                // failed-and-not-dismissed connect, so typing died until
+                // the connecting tab was closed.
+                let connecting_here = self
+                    .connecting
+                    .as_ref()
+                    .is_some_and(|cp| Some(cp.tab_idx) == self.active_tab);
                 if let Some(tab_idx) = self.active_tab
-                    && self.connecting.is_none()
+                    && !connecting_here
                     && let keyboard::Event::KeyPressed {
                         key,
                         modified_key,

--- a/crates/oryxis-app/src/dispatch_terminal/mod.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/mod.rs
@@ -737,8 +737,16 @@ impl Oryxis {
                 if self.cursor_over_sidebar() {
                     return Task::none();
                 }
+                // Same per-tab scoping as the KeyboardEvent PTY gate: the
+                // connect screen covers only its own tab, so a tab switched
+                // away from an in-flight / failed connect keeps its IME
+                // commits (the old app-global `connecting.is_none()` ate
+                // them until the connecting tab was closed).
                 if let Some(tab_idx) = self.active_tab
-                    && self.connecting.is_none()
+                    && !self
+                        .connecting
+                        .as_ref()
+                        .is_some_and(|cp| Some(cp.tab_idx) == self.active_tab)
                 {
                     let bytes = text.into_bytes();
                     self.write_input_to_tab(tab_idx, &bytes);

--- a/crates/oryxis-app/src/dispatch_terminal/mod.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/mod.rs
@@ -774,6 +774,21 @@ impl Oryxis {
             // clears it. Purely visual: nothing is written to the PTY until
             // the composition commits.
             TerminalMessage::TerminalImePreedit(text) => {
+                // Same surface guards as `TerminalImeCommit`: IME events
+                // reach this subscription even while a text_input owns the
+                // composition (host panel field, modal, sidebar chat), and
+                // without these the grid would paint someone else's
+                // composition at the caret. An empty preedit (composition
+                // ended or the IME closed) always lands, so a surface
+                // opening mid-composition can never strand a ghost on the
+                // grid.
+                if !text.is_empty()
+                    && (self.panels.host_panel
+                        || self.any_modal_blocks_input()
+                        || self.cursor_over_sidebar())
+                {
+                    return Task::none();
+                }
                 if let Some(tab_idx) = self.active_tab
                     && let Some(tab) = self.tabs.get(tab_idx)
                     && let Ok(mut state) = tab.active().terminal.lock()

--- a/crates/oryxis-app/src/dispatch_terminal/mod.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/mod.rs
@@ -159,7 +159,18 @@ impl Oryxis {
                 if let Some(tab_idx) = self.active_tab
                     && let Some(tab) = self.tabs.get_mut(tab_idx)
                 {
+                    // A composition interrupted mid-way (focus clicks onto
+                    // another pane) leaves stale preedit on the pane being
+                    // left; clear it or the overlay would re-show an
+                    // already-abandoned composition when the user returns.
+                    let old = tab.focused;
                     tab.focused = pane;
+                    if old != pane
+                        && let Some(old_pane) = tab.pane_grid.get(old)
+                        && let Ok(mut state) = old_pane.terminal.lock()
+                    {
+                        state.set_preedit(String::new());
+                    }
                 }
                 // Clicking a terminal pane takes the keyboard back from the
                 // sidebar ring (see write_input_to_tab for the rationale),
@@ -750,6 +761,24 @@ impl Oryxis {
                 {
                     let bytes = text.into_bytes();
                     self.write_input_to_tab(tab_idx, &bytes);
+                    // The commit ends any active composition; winit usually
+                    // sends an empty Preedit first, but clear defensively so
+                    // a stale preedit can never linger on the overlay.
+                    self.clear_focused_pane_preedit();
+                }
+            }
+            // IME composition (preedit) update, e.g. pinyin syllables. Stored
+            // on the focused pane's TerminalState; the `ime_host` widget
+            // reports it to the iced runtime on the next redraw so the
+            // over-the-spot overlay renders it at the caret. An empty string
+            // clears it. Purely visual: nothing is written to the PTY until
+            // the composition commits.
+            TerminalMessage::TerminalImePreedit(text) => {
+                if let Some(tab_idx) = self.active_tab
+                    && let Some(tab) = self.tabs.get(tab_idx)
+                    && let Ok(mut state) = tab.active().terminal.lock()
+                {
+                    state.set_preedit(text);
                 }
             }
         }
@@ -762,6 +791,17 @@ impl Oryxis {
         self.tabs
             .iter()
             .position(|t| t.pane_grid.panes.values().any(|p| p.id == pane_id))
+    }
+
+    /// Clear the IME preedit of the focused pane of the active tab. Called
+    /// when a composition commits so a stale overlay can never linger.
+    fn clear_focused_pane_preedit(&mut self) {
+        if let Some(tab_idx) = self.active_tab
+            && let Some(tab) = self.tabs.get(tab_idx)
+            && let Ok(mut state) = tab.active().terminal.lock()
+        {
+            state.set_preedit(String::new());
+        }
     }
 
     /// Find a pane by its stable id across every tab (shared read).

--- a/crates/oryxis-app/src/messages/ssh.rs
+++ b/crates/oryxis-app/src/messages/ssh.rs
@@ -22,10 +22,14 @@ pub enum SshMessage {
     /// Protocol badge picked on the quick-connect card (issue #174),
     /// for the case where the typed text names no `scheme://`.
     QuickConnectProtocolPicked(oryxis_core::models::connection::ConnectionProtocol),
-    SshProgress(ConnectionStep, String),
+    /// Progress step for the dial of `(pane_id)`. The pane id is part of
+    /// the message so a later, unrelated connect can't capture an earlier
+    /// dial's timeline on its progress card (concurrent tabs).
+    SshProgress(Uuid, ConnectionStep, String),
     /// Pre-auth banner (RFC 4252 §5.4) for the connect in progress:
-    /// shown on the progress card and written to the tab's terminal.
-    SshBanner(String),
+    /// `(pane_id, text)`; shown on the progress card (when it is tracking
+    /// this pane's dial) and written to that pane's tab terminal.
+    SshBanner(Uuid, String),
     /// Pre-auth banner for a split-pane connect (no progress card):
     /// written straight to that pane's terminal.
     SshPaneBanner(Uuid, String),
@@ -39,7 +43,11 @@ pub enum SshMessage {
     ReuseFailedDialFresh(Uuid),
 
     SshDisconnected(Uuid),  // (pane_id)
-    SshError(String),
+    /// A tab-connect dial failed: `(pane_id, error)`. The pane id lets the
+    /// error land on the progress card that is actually tracking this dial;
+    /// a failure for a dial whose card was superseded by a newer connect
+    /// falls back to writing into that pane's terminal instead.
+    SshError(Uuid, String),
     /// Handshake hit "no common algorithm". Prompts the legacy-fallback
     /// dialog for `conn_id` (the failed category + what the server offered).
     SshNoCommonAlgo {

--- a/crates/oryxis-app/src/messages/terminal.rs
+++ b/crates/oryxis-app/src/messages/terminal.rs
@@ -76,6 +76,11 @@ pub enum TerminalMessage {
     /// Arrives separately from `KeyboardEvent`; forwarded to the active
     /// PTY in `dispatch_terminal` behind the same focus guards.
     TerminalImeCommit(String),
+    /// IME preedit (composition) update, e.g. the pinyin syllables while a
+    /// CJK input method is composing. Stored on the focused pane's
+    /// `TerminalState` so the `ime_host` overlay can render it at the
+    /// caret; an empty string clears it.
+    TerminalImePreedit(String),
     /// Focus a pane (click). Routes keyboard / snippets / paste to it.
     FocusPane(iced::widget::pane_grid::Pane),
     /// Drag a pane divider to resize.

--- a/crates/oryxis-app/src/subscription.rs
+++ b/crates/oryxis-app/src/subscription.rs
@@ -74,6 +74,22 @@ impl Oryxis {
                 iced::event::Event::InputMethod(
                     iced::advanced::input_method::Event::Commit(text),
                 ) => Some(Message::Terminal(TerminalMessage::TerminalImeCommit(text))),
+                // Composition (preedit) updates: pinyin syllables, kana,
+                // etc. while an IME is composing. Stored on the focused
+                // pane so the `ime_host` overlay draws them at the caret;
+                // an empty string (or the IME closing) clears it. The
+                // cursor-range hint is ignored: the terminal's caret is
+                // where the composed text belongs.
+                iced::event::Event::InputMethod(
+                    iced::advanced::input_method::Event::Preedit(text, _),
+                ) => Some(Message::Terminal(TerminalMessage::TerminalImePreedit(
+                    text,
+                ))),
+                iced::event::Event::InputMethod(iced::advanced::input_method::Event::Closed) => {
+                    Some(Message::Terminal(TerminalMessage::TerminalImePreedit(
+                        String::new(),
+                    )))
+                }
                 iced::event::Event::Mouse(iced::mouse::Event::CursorMoved { position }) => {
                     // Always record the raw position (cheap, no message):
                     // `update()` syncs `self.mouse_position` from these on

--- a/crates/oryxis-app/src/widgets/overlay.rs
+++ b/crates/oryxis-app/src/widgets/overlay.rs
@@ -506,9 +506,11 @@ pub(crate) fn scroll_into_view_task(
 /// itself arrives as `Event::InputMethod(Commit(..))` and is routed to the
 /// PTY in `subscription.rs` / `dispatch_terminal.rs`, not here.
 ///
-/// The candidate box is anchored near the bottom-left (the usual prompt row)
-/// rather than the live caret. Caret-following is a future polish; this keeps
-/// the popup on-screen and functional.
+/// The candidate box is anchored at the live caret (the pane's drawn cell)
+/// and the composed preedit is drawn INLINE on the grid by the terminal
+/// widget itself (terminal font, at the caret), so we deliberately report
+/// `preedit: None`: the runtime's over-the-spot overlay would otherwise
+/// double-paint the composition in a second font.
 pub(crate) fn ime_host<'a, Message: 'a>(
     content: impl Into<Element<'a, Message>>,
     enabled: bool,
@@ -599,9 +601,12 @@ pub(crate) fn ime_host<'a, Message: 'a>(
                 )
             {
                 let b = layout.bounds();
-                // Anchor the candidate window at the terminal caret. try_lock
-                // so a frame that races the render thread just falls back to
-                // the bottom-left instead of blocking the UI.
+                // Anchor the OS candidate window at the terminal caret.
+                // try_lock so a frame that races the render thread just
+                // falls back to the bottom-left instead of blocking the UI.
+                // The composed preedit is drawn inline by the terminal
+                // widget itself, so `preedit` stays `None` here (no
+                // over-the-spot overlay, no double paint).
                 let cursor_area = match self.terminal.try_lock() {
                     Ok(state) => oryxis_terminal::ime_caret_rect(
                         b,
@@ -620,7 +625,10 @@ pub(crate) fn ime_host<'a, Message: 'a>(
                 };
                 let ime: input_method::InputMethod = input_method::InputMethod::Enabled {
                     cursor: cursor_area,
-                    purpose: input_method::Purpose::Normal,
+                    // A terminal surface: lets Wayland shape the OSK for a
+                    // PTY (extra keys, layout hints) instead of the generic
+                    // text-field form.
+                    purpose: input_method::Purpose::Terminal,
                     preedit: None,
                 };
                 shell.request_input_method(&ime);

--- a/crates/oryxis-terminal/Cargo.toml
+++ b/crates/oryxis-terminal/Cargo.toml
@@ -20,6 +20,9 @@ regex = { workspace = true }
 # performed by the host through the iced runtime, so the process only ever
 # has one clipboard operation in flight. See `host_clipboard` for the
 # STATUS_HEAP_CORRUPTION crash that rule comes from.
+# Character width for the inline IME preedit layout (CJK double-width
+# cells); already in the tree via alacritty_terminal.
+unicode-width = "0.2"
 
 # `ShellExecuteW`, so Ctrl+click on a link reaches the OS handler without
 # a shell in between. The `cmd /C start` shim it replaces let a byte the

--- a/crates/oryxis-terminal/src/widget/draw.rs
+++ b/crates/oryxis-terminal/src/widget/draw.rs
@@ -237,6 +237,8 @@ where
             in_alt_screen,
             scroll_offset,
             ghost,
+            preedit,
+            cols_count,
         ) = {
             let mut state = match self.state.lock() {
                 Ok(s) => s,
@@ -440,6 +442,8 @@ where
                 in_alt_screen,
                 scroll_offset,
                 ghost,
+                state.preedit().to_string(),
+                cols_count,
             )
         };
         let palette = &palette;
@@ -975,31 +979,83 @@ where
         if (0..screen_lines as i32).contains(&visible_cursor_row) {
             let cx = cursor.point.column.0 as f32 * cell_w + TERM_PAD;
             let cy = visible_cursor_row as f32 * cell_h + TERM_PAD_TOP;
-            match cursor.shape {
+            // Paint the caret shape at an arbitrary cell origin, shared by
+            // the normal caret and the end of an inline IME composition.
+            let paint_cursor = |frame: &mut Frame, x: f32| match cursor.shape {
                 CursorShape::Block => {
                     frame.fill_rectangle(
-                        Point::new(cx, cy),
+                        Point::new(x, cy),
                         Size::new(cell_w, cell_h),
                         Color { a: 0.7, ..palette.cursor },
                     );
                 }
                 CursorShape::Beam => {
-                    frame.fill_rectangle(Point::new(cx, cy), Size::new(2.0, cell_h), palette.cursor);
+                    frame.fill_rectangle(Point::new(x, cy), Size::new(2.0, cell_h), palette.cursor);
                 }
                 CursorShape::Underline => {
                     frame.fill_rectangle(
-                        Point::new(cx, cy + cell_h - 2.0),
+                        Point::new(x, cy + cell_h - 2.0),
                         Size::new(cell_w, 2.0),
                         palette.cursor,
                     );
                 }
                 _ => {
                     frame.fill_rectangle(
-                        Point::new(cx, cy),
+                        Point::new(x, cy),
                         Size::new(cell_w, cell_h),
                         Color { a: 0.5, ..palette.cursor },
                     );
                 }
+            };
+            // Inline IME preedit: while a composition is active the caret
+            // row shows the composed text in the terminal font, one glyph
+            // per cell from the caret (CJK wide glyphs take two cells),
+            // underlined to mark the composition region (Windows Terminal /
+            // alacritty style). The caret moves to the end of the composed
+            // text and the normal cursor is not drawn; the composition
+            // clips at the right edge of the grid.
+            if !preedit.is_empty() {
+                let mut pen_x = cx;
+                let mut end_col = cursor.point.column.0;
+                for ch in preedit.chars() {
+                    let w =
+                        unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0).max(1);
+                    if end_col + w > cols_count {
+                        break;
+                    }
+                    // Semi-transparent backing so the composition stays
+                    // readable over a colourful cell behind it (vim
+                    // highlight, a selection, a bright ANSI background):
+                    // the composed text is not part of the grid, so it
+                    // must not inherit whatever the cell carries. RGB
+                    // comes from the palette background (works on
+                    // transparent backdrops too, alpha is ours).
+                    frame.fill_rectangle(
+                        Point::new(pen_x, cy),
+                        Size::new(w as f32 * cell_w, cell_h),
+                        Color { a: 0.45, ..palette.background },
+                    );
+                    stamp(
+                        frame,
+                        ch.to_string(),
+                        Point::new(pen_x, cy),
+                        palette.foreground,
+                        self.font,
+                    );
+                    // Composition underline at the same height as the
+                    // `CursorShape::Underline` caret, so the region reads
+                    // as "being edited" rather than a separate element.
+                    frame.fill_rectangle(
+                        Point::new(pen_x, cy + cell_h - 2.0),
+                        Size::new(w as f32 * cell_w, 2.0),
+                        Color { a: 0.8, ..palette.foreground },
+                    );
+                    pen_x += w as f32 * cell_w;
+                    end_col += w;
+                }
+                paint_cursor(frame, pen_x);
+            } else {
+                paint_cursor(frame, cx);
             }
         }
 

--- a/crates/oryxis-terminal/src/widget/state.rs
+++ b/crates/oryxis-terminal/src/widget/state.rs
@@ -44,6 +44,12 @@ pub struct TerminalState {
     /// chip. `None` when the pointer is over no explicit link. Updated by
     /// the widget's hover handler under the render lock.
     pub hovered_link: Option<HoveredLink>,
+    /// IME preedit (composition) text for this pane, e.g. the pinyin
+    /// syllables while a CJK input method is composing. The app stores it
+    /// from `InputMethod::Preedit` events; the `ime_host` widget reports it
+    /// back to the iced runtime so the over-the-spot overlay can draw it at
+    /// the caret. Empty string means "no active composition".
+    preedit: String,
 }
 
 impl TerminalState {
@@ -69,7 +75,7 @@ impl TerminalState {
         let (pty, rx) =
             PtyHandle::spawn_command(cols, rows, None, &[], cwd, env, &backend.event_proxy)?;
         let palette = TerminalPalette::default();
-        Ok((Self { backend, pty: Some(pty), palette, remote_resize_tx: None, render_epoch: 0, search: None, pending_scroll: std::cell::Cell::new(None), hovered_link: None }, rx))
+        Ok((Self { backend, pty: Some(pty), palette, remote_resize_tx: None, render_epoch: 0, search: None, pending_scroll: std::cell::Cell::new(None), hovered_link: None, preedit: String::new() }, rx))
     }
 
     /// Like `new` but spawns an explicit program (e.g. PowerShell or
@@ -102,7 +108,7 @@ impl TerminalState {
             cols, rows, Some(program), args, cwd, env, &backend.event_proxy,
         )?;
         let palette = TerminalPalette::default();
-        Ok((Self { backend, pty: Some(pty), palette, remote_resize_tx: None, render_epoch: 0, search: None, pending_scroll: std::cell::Cell::new(None), hovered_link: None }, rx))
+        Ok((Self { backend, pty: Some(pty), palette, remote_resize_tx: None, render_epoch: 0, search: None, pending_scroll: std::cell::Cell::new(None), hovered_link: None, preedit: String::new() }, rx))
     }
 
     pub fn new_no_pty(
@@ -111,7 +117,7 @@ impl TerminalState {
     ) -> TerminalResult<Self> {
         let backend = TerminalBackend::new(cols, rows);
         let palette = TerminalPalette::default();
-        Ok(Self { backend, pty: None, palette, remote_resize_tx: None, render_epoch: 0, search: None, pending_scroll: std::cell::Cell::new(None), hovered_link: None })
+        Ok(Self { backend, pty: None, palette, remote_resize_tx: None, render_epoch: 0, search: None, pending_scroll: std::cell::Cell::new(None), hovered_link: None, preedit: String::new() })
     }
 
     /// A PTY-less state with an explicit scrollback budget, for the
@@ -125,7 +131,7 @@ impl TerminalState {
     ) -> TerminalResult<Self> {
         let backend = TerminalBackend::new_with_scrollback(cols, rows, scrollback);
         let palette = TerminalPalette::default();
-        Ok(Self { backend, pty: None, palette, remote_resize_tx: None, render_epoch: 0, search: None, pending_scroll: std::cell::Cell::new(None), hovered_link: None })
+        Ok(Self { backend, pty: None, palette, remote_resize_tx: None, render_epoch: 0, search: None, pending_scroll: std::cell::Cell::new(None), hovered_link: None, preedit: String::new() })
     }
 
     /// Wire a remote resize sender, called from the app once an SSH
@@ -767,6 +773,23 @@ impl TerminalState {
         (p.column.0 as u16, p.line.0.max(0) as u16)
     }
 
+    /// Store the OS IME preedit (composition) text, e.g. pinyin syllables
+    /// while a CJK method is composing. Empty means "no active composition".
+    /// Drawn inline on the grid by the widget (terminal font, at the
+    /// caret); the `ime_host` decorator only anchors the OS candidate
+    /// window. Bumps the render epoch so the canvas geometry cache
+    /// re-tessellates with the new composition (it is part of what a
+    /// frame draws).
+    pub fn set_preedit(&mut self, text: String) {
+        self.preedit = text;
+        self.render_epoch = self.render_epoch.wrapping_add(1);
+    }
+
+    /// The current IME preedit text (empty when idle).
+    pub fn preedit(&self) -> &str {
+        &self.preedit
+    }
+
     /// Extract text from a selection range.
     pub fn get_selection_text(&self, sel: &Selection) -> String {
         use alacritty_terminal::grid::Dimensions;
@@ -1087,6 +1110,21 @@ pub struct RegionText {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The IME preedit round-trip the `ime_host` overlay depends on: the app
+    /// stores composition text on the state, the overlay reads it back on the
+    /// next redraw, and an empty string (commit / IME close) hides it again.
+    #[test]
+    fn preedit_round_trips_and_empty_clears() {
+        let mut state = TerminalState::new_no_pty(24, 80).expect("headless state");
+        assert!(state.preedit().is_empty(), "idle state has no preedit");
+
+        state.set_preedit("nihao".to_string());
+        assert_eq!(state.preedit(), "nihao");
+
+        state.set_preedit(String::new());
+        assert!(state.preedit().is_empty(), "empty preedit clears the overlay");
+    }
 
     /// The canvas geometry cache keys off `render_epoch`: a stale epoch
     /// after real output or a palette swap would leave the terminal showing


### PR DESCRIPTION
## Problem
While composing with a CJK input method (e.g. pinyin), the in-progress text was invisible in the terminal — keystrokes during composition had no visible feedback, even though the final commit typed correctly.

## Fix
Draw the IME preedit inline in the grid at the caret, Windows Terminal / alacritty style:
- composed text in the terminal's monospace font, one glyph per cell from the caret (CJK wide glyphs take two cells)
- the composition region is underlined, the caret moves to the end of the composition, and the normal cursor is suppressed while composing
- the composition clips at the right edge of the grid
- a semi-transparent backing keeps it readable over coloured cells (vim highlight, selections, bright ANSI backgrounds)

The preedit is stored on the focused pane's `TerminalState` and cleared on commit, tab switch, or focus change so no ghost composition can linger. The winit overlay is told to report `preedit: None` so it stops double-rendering the composition in the UI font.

## Changes
- `oryxis-terminal/src/widget/state.rs` — `preedit` field + accessors (bumps render epoch so geometry caches invalidate)
- `oryxis-terminal/src/widget/draw.rs` — inline preedit painting in the caret row
- `oryxis-app/src/subscription.rs` — forward IME `Preedit`/`Closed` events
- `oryxis-app/src/dispatch_terminal/mod.rs` — `TerminalImePreedit` handler; clear on commit/focus change
- `oryxis-app/src/dispatch_tabs/lifecycle.rs` — clear on tab switch
- `oryxis-app/src/widgets/overlay.rs` — `ime_host` reports `preedit: None` + `Purpose::Terminal`
- `oryxis-terminal/Cargo.toml` — new `unicode-width` dependency (already pinned in the lockfile)

## Validation
- `cargo check -p oryxis-app --offline` ✓
- `cargo test -p oryxis-app --offline` (845 passed) ✓
- `cargo test -p oryxis-terminal --offline` (214 passed) ✓