### PR TITLE
Ask before overwriting on terminal / sidebar drop uploads

### DIFF
--- a/crates/oryxis-app/src/dispatch_settings/local_terminals.rs
+++ b/crates/oryxis-app/src/dispatch_settings/local_terminals.rs
@@ -631,8 +631,10 @@ pub(crate) fn list_wsl_distros() -> Vec<String> {
     // u16 pairs.
     let bytes = out.stdout;
     let utf16: Vec<u16> = bytes
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| u16::from_le_bytes(*c))
         .collect();
     String::from_utf16_lossy(&utf16)
         .lines()

--- a/crates/oryxis-app/src/dispatch_sftp_transfers/conflict.rs
+++ b/crates/oryxis-app/src/dispatch_sftp_transfers/conflict.rs
@@ -31,6 +31,14 @@ impl Oryxis {
                 let Some(prompt) = self.sftp.overwrite_prompt.take() else {
                     return Ok(Task::none());
                 };
+                // Terminal / sidebar Files drop upload conflicts are
+                // intercepted earlier in `handle_sftp_transfers` (they
+                // must resolve even with no SFTP tab open); a prompt
+                // reaching here without a queue behind it is a stale
+                // drop conflict, so decline it instead of guessing.
+                if prompt.drop_upload_pane.is_some() {
+                    return Ok(Task::none());
+                }
                 let apply_to_all = prompt.apply_to_all;
                 let temp_name = self.prefs.sftp_upload_temp_name;
                 let downloading =

--- a/crates/oryxis-app/src/dispatch_sftp_transfers/mod.rs
+++ b/crates/oryxis-app/src/dispatch_sftp_transfers/mod.rs
@@ -96,6 +96,44 @@ impl Oryxis {
         &mut self,
         message: SftpMessage,
     ) -> Result<Task<Message>, SftpMessage> {
+        // A terminal / sidebar Files drop conflict's modal answers land
+        // here even with no SFTP tab open: the resume targets the
+        // pane's paused drop upload, not any SFTP surface. The owner
+        // gate below would otherwise decline them into `Task::none` and
+        // the upload would stay paused forever.
+        match &message {
+            SftpMessage::SftpToggleApplyToAll
+                if self
+                    .sftp
+                    .overwrite_prompt
+                    .as_ref()
+                    .is_some_and(|p| p.drop_upload_pane.is_some()) =>
+            {
+                if let Some(p) = self.sftp.overwrite_prompt.as_mut() {
+                    p.apply_to_all = !p.apply_to_all;
+                }
+                return Ok(Task::none());
+            }
+            SftpMessage::SftpResolveOverwrite(action)
+                if self
+                    .sftp
+                    .overwrite_prompt
+                    .as_ref()
+                    .is_some_and(|p| p.drop_upload_pane.is_some()) =>
+            {
+                let prompt = self.sftp.overwrite_prompt.take();
+                let pane_id = prompt.as_ref().and_then(|p| p.drop_upload_pane);
+                let apply_to_all = prompt.map(|p| p.apply_to_all).unwrap_or(false);
+                if let Some(pane_id) = pane_id {
+                    return Ok(self.resolve_terminal_drop_conflict(
+                        pane_id,
+                        *action,
+                        apply_to_all,
+                    ));
+                }
+            }
+            _ => {}
+        }
         let Some(owner) = self.current_sftp_owner() else {
             return Err(message);
         };

--- a/crates/oryxis-app/src/dispatch_terminal/drop.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/drop.rs
@@ -396,9 +396,27 @@ impl Oryxis {
             temp_name,
         } = paused;
         let entry_start = index;
+        // Cancel with "apply to all" drops the rest of the batch, the
+        // panel's own sticky-cancel semantics (`handle_sftp_conflict`
+        // clears the queue): the user asked to stop the drop, not to
+        // keep uploading around every conflict. One terminal event
+        // still clears the card and toasts.
+        if apply_to_all && matches!(action, crate::state::OverwriteAction::Cancel) {
+            return Task::done(Message::Terminal(TerminalMessage::TerminalDropProgress(
+                pane_id,
+                DropProgress::Cancelled,
+            )));
+        }
         // Sticky answer when the user ticked "apply to all": every later
-        // conflict applies it instead of asking again.
-        let sticky = apply_to_all.then_some(action);
+        // conflict applies it instead of asking again. Resume is
+        // deliberately never sticky, same rule as the panel handler: the
+        // engine can check that THIS destination's tail belongs to THIS
+        // source, which says nothing about the next pair, and a sticky
+        // "continue" would be guessing at whether to splice two files it
+        // has not seen.
+        let sticky = (apply_to_all
+            && !matches!(action, crate::state::OverwriteAction::Resume))
+        .then_some(action);
         // The first remaining item is the conflicted file; pop it so the
         // answer can be applied before the loop resumes.
         let conflict = plans
@@ -430,23 +448,38 @@ impl Oryxis {
                 };
 
                 let mut completed = completed;
-                if let Some(item) = conflict
-                    && !matches!(action, crate::state::OverwriteAction::Cancel)
-                {
-                    let counter = Arc::new(AtomicU64::new(0));
-                    if let Err(e) = crate::sftp_helpers::apply_overwrite_for_item(
-                        client.clone(),
-                        item,
-                        action,
-                        temp_name,
-                        Some(Arc::clone(&counter)),
-                    )
-                    .await
-                    {
-                        send(DropProgress::Failed(e)).await;
-                        return;
+                if let Some(item) = conflict {
+                    if matches!(action, crate::state::OverwriteAction::Cancel) {
+                        // Skipped, not transferred: count its planned size
+                        // anyway so the bar still sums to the total.
+                        completed += item.size.unwrap_or(0);
+                    } else {
+                        let counter = Arc::new(AtomicU64::new(0));
+                        match watched_apply_overwrite(
+                            &send, &client, &item, action, temp_name, &abort, completed, &counter,
+                        )
+                        .await
+                        {
+                            Ok(WatchedApply::Finished) => {}
+                            Ok(WatchedApply::Aborted) => {
+                                send(DropProgress::Cancelled).await;
+                                return;
+                            }
+                            Ok(WatchedApply::ChannelClosed) => return,
+                            Err(e) => {
+                                send(DropProgress::Failed(e)).await;
+                                return;
+                            }
+                        }
+                        // Replace-if-different may skip (equal sizes) and
+                        // Resume moves fewer bytes than the planned size:
+                        // count the larger of planned and moved so the bar
+                        // still sums to the total.
+                        completed += item
+                            .size
+                            .unwrap_or(0)
+                            .max(counter.load(Ordering::Relaxed));
                     }
-                    completed += counter.load(Ordering::Relaxed);
                     if !send(DropProgress::Advanced { transferred: completed }).await {
                         return;
                     }
@@ -562,7 +595,11 @@ impl Oryxis {
         // A destination conflict paused the drop upload: raise the
         // overwrite modal. The pane keeps the paused context; answering
         // the modal resumes the upload through
-        // `resolve_terminal_drop_conflict`.
+        // `resolve_terminal_drop_conflict`. Last-writer-wins like the
+        // queue runners' own raise site (`SftpTransferConflict`): a
+        // prompt already up for another surface would be replaced here
+        // and its transfer left parked. Both raisers share that
+        // limitation; lifting it takes a prompt queue across surfaces.
         if let Some(prompt) = park_prompt {
             self.sftp.overwrite_prompt = Some(prompt);
         }
@@ -587,10 +624,12 @@ impl Oryxis {
 /// (`begin_drop_sftp_upload`) and a paused-then-resumed one
 /// (`resolve_terminal_drop_conflict`).
 ///
-/// Every file item checks its destination first: a pre-existing file with
-/// no sticky default pauses the whole drop (emitting `Conflict`, which the
-/// update loop turns into the overwrite modal) instead of overwriting
-/// silently. Folders merge tolerantly, mirroring the panel uploader.
+/// Every top-level FILE checks its destination first: a pre-existing file
+/// with no sticky default pauses the whole drop (emitting `Conflict`,
+/// which the update loop turns into the overwrite modal) instead of
+/// overwriting silently. Folder plans upload under a fresh collision-free
+/// root, so their children skip the check entirely; the directories
+/// themselves merge tolerantly, mirroring the panel uploader.
 #[allow(clippy::too_many_arguments)]
 async fn run_drop_upload_plans(
     send: &(dyn Fn(DropProgress) -> BoxFuture<'static, bool> + Send + Sync),
@@ -617,6 +656,12 @@ async fn run_drop_upload_plans(
             return;
         }
         let item_count = plan_items.len();
+        // A folder plan uploads under a fresh collision-free root
+        // (`unique_name_in_remote_dir`), so its children cannot conflict
+        // by construction; only top-level file plans probe the
+        // destination. That keeps the cost at one `list_dir` per dropped
+        // file, never one per child of a dropped tree.
+        let checks_conflict = plan_items.first().is_some_and(|i| !i.is_dir);
         for item_idx in 0..item_count {
             let item = &plan_items[item_idx];
             if abort.load(Ordering::Relaxed) {
@@ -638,80 +683,92 @@ async fn run_drop_upload_plans(
             // Conflict gate: a pre-existing destination asks instead of
             // silently overwriting (or silently renaming, the old drop
             // behavior). Mirrors the panel queue's per-item check.
-            let parent = crate::sftp_helpers::parent_path(&item.dst);
-            let basename = item
-                .dst
-                .rsplit('/')
-                .find(|s| !s.is_empty())
-                .unwrap_or(&item.dst)
-                .to_string();
-            let entries = match client.list_dir(&parent).await {
-                Ok(e) => e,
-                Err(e) => {
-                    send(DropProgress::Failed(e.to_string())).await;
+            if checks_conflict {
+                let parent = crate::sftp_helpers::parent_path(&item.dst);
+                let basename = item
+                    .dst
+                    .rsplit('/')
+                    .find(|s| !s.is_empty())
+                    .unwrap_or(&item.dst)
+                    .to_string();
+                let entries = match client.list_dir(&parent).await {
+                    Ok(e) => e,
+                    Err(e) => {
+                        send(DropProgress::Failed(e.to_string())).await;
+                        return;
+                    }
+                };
+                if let Some(existing) = entries.iter().find(|e| e.name == basename) {
+                    if let Some(action) = overwrite_default {
+                        let counter = Arc::new(AtomicU64::new(0));
+                        match watched_apply_overwrite(
+                            send, client, item, action, temp_name, &abort, completed, &counter,
+                        )
+                        .await
+                        {
+                            Ok(WatchedApply::Finished) => {}
+                            Ok(WatchedApply::Aborted) => {
+                                send(DropProgress::Cancelled).await;
+                                return;
+                            }
+                            Ok(WatchedApply::ChannelClosed) => return,
+                            Err(e) => {
+                                send(DropProgress::Failed(e)).await;
+                                return;
+                            }
+                        }
+                        // Same accounting as the resolve handler: count
+                        // the larger of planned and moved so a skipping
+                        // replace-if-different still advances the bar.
+                        completed += item
+                            .size
+                            .unwrap_or(0)
+                            .max(counter.load(Ordering::Relaxed));
+                        if !send(DropProgress::Advanced { transferred: completed }).await {
+                            return;
+                        }
+                        continue;
+                    }
+                    let src_size = tokio::fs::metadata(&item.src)
+                        .await
+                        .map(|m| m.len())
+                        .unwrap_or(0);
+                    let prompt = crate::state::OverwritePrompt {
+                        dst_dir: parent,
+                        basename,
+                        src_size,
+                        dst_size: existing.size,
+                        direction: crate::state::OverwriteDirection::Upload,
+                        multi: of > 1,
+                        apply_to_all: false,
+                        owner: None,
+                        drop_upload_pane: Some(pane_id),
+                    };
+                    // Everything still to do, this conflicted item first, so
+                    // the resolve handler can apply the answer and continue.
+                    let mut rest: Vec<(String, Vec<crate::state::TransferItem>)> = Vec::new();
+                    rest.push((name.clone(), plan_items[item_idx..].to_vec()));
+                    for (pname, pitems) in plans.iter().skip(plan_idx + 1) {
+                        rest.push((pname.clone(), pitems.clone()));
+                    }
+                    send(DropProgress::Conflict {
+                        prompt: Box::new(prompt),
+                        item: item.clone(),
+                        paused: crate::state::DropUploadPaused {
+                            plans: rest,
+                            completed,
+                            // 0-based global entry position; the resume uses
+                            // it as its `entry_start` so the displayed
+                            // `(k, n)` batch position does not advance twice.
+                            index: entry_start + plan_idx,
+                            of,
+                            dest_dir: dest_dir.clone(),
+                            temp_name,
+                        },
+                    })
+                    .await;
                     return;
                 }
-            };
-            if let Some(existing) = entries.iter().find(|e| e.name == basename) {
-                if let Some(action) = overwrite_default {
-                    let counter = Arc::new(AtomicU64::new(0));
-                    if let Err(e) = crate::sftp_helpers::apply_overwrite_for_item(
-                        client.clone(),
-                        item.clone(),
-                        action,
-                        temp_name,
-                        Some(Arc::clone(&counter)),
-                    )
-                    .await
-                    {
-                        send(DropProgress::Failed(e)).await;
-                        return;
-                    }
-                    completed += counter.load(Ordering::Relaxed);
-                    if !send(DropProgress::Advanced { transferred: completed }).await {
-                        return;
-                    }
-                    continue;
-                }
-                let src_size = tokio::fs::metadata(&item.src)
-                    .await
-                    .map(|m| m.len())
-                    .unwrap_or(0);
-                let prompt = crate::state::OverwritePrompt {
-                    dst_dir: parent,
-                    basename,
-                    src_size,
-                    dst_size: existing.size,
-                    direction: crate::state::OverwriteDirection::Upload,
-                    multi: of > 1,
-                    apply_to_all: false,
-                    owner: None,
-                    drop_upload_pane: Some(pane_id),
-                };
-                // Everything still to do, this conflicted item first, so
-                // the resolve handler can apply the answer and continue.
-                let mut rest: Vec<(String, Vec<crate::state::TransferItem>)> = Vec::new();
-                rest.push((name.clone(), plan_items[item_idx..].to_vec()));
-                for (pname, pitems) in plans.iter().skip(plan_idx + 1) {
-                    rest.push((pname.clone(), pitems.clone()));
-                }
-                send(DropProgress::Conflict {
-                    prompt: Box::new(prompt),
-                    item: item.clone(),
-                    paused: crate::state::DropUploadPaused {
-                        plans: rest,
-                        completed,
-                        // 0-based global entry position; the resume uses
-                        // it as its `entry_start` so the displayed
-                        // `(k, n)` batch position does not advance twice.
-                        index: entry_start + plan_idx,
-                        of,
-                        dest_dir: dest_dir.clone(),
-                        temp_name,
-                    },
-                })
-                .await;
-                return;
             }
             // No conflict: upload with progress ticks.
             let counter = Arc::new(AtomicU64::new(0));
@@ -767,6 +824,89 @@ async fn run_drop_upload_plans(
         }
     }
     send(DropProgress::Done).await;
+}
+
+/// Outcome of `watched_apply_overwrite`. `ChannelClosed` means a progress
+/// send failed: the UI is gone, so the caller just ends the stream
+/// without another event.
+enum WatchedApply {
+    Finished,
+    Aborted,
+    ChannelClosed,
+}
+
+/// Run an overwrite apply under the same 120 ms watch loop as a plain
+/// upload, so the card keeps advancing and the overlay cancel is not
+/// deaf for the whole file. Mid-flight cancel only sweeps where the
+/// sweep is provably safe; everything else cancels at the next file
+/// boundary instead (the outer loop's per-item abort check), which
+/// never leaves a spliced resume or an orphan half-duplicate behind.
+#[allow(clippy::too_many_arguments)]
+async fn watched_apply_overwrite(
+    send: &(dyn Fn(DropProgress) -> BoxFuture<'static, bool> + Send + Sync),
+    client: &oryxis_ssh::SftpClient,
+    item: &crate::state::TransferItem,
+    action: crate::state::OverwriteAction,
+    temp_name: bool,
+    abort: &Arc<AtomicBool>,
+    completed: u64,
+    counter: &Arc<AtomicU64>,
+) -> Result<WatchedApply, String> {
+    let sweepable = if temp_name {
+        // Scratch mode: the bytes went to `<dst>.oryxis-part`, so the
+        // sweep can only ever remove our own partial, never the file
+        // being replaced.
+        matches!(
+            action,
+            crate::state::OverwriteAction::Replace
+                | crate::state::OverwriteAction::ReplaceIfDifferent
+        )
+    } else {
+        // Direct mode truncates `dst` on open, so a cancelled Replace
+        // must sweep the damaged file (the user chose to forfeit it).
+        // Replace-if-different may finish WITHOUT touching `dst` at all
+        // (equal sizes): sweeping could delete the intact file the
+        // action just decided to keep, so it is boundary-only here.
+        // Resume appends into the file the user chose to continue and
+        // Duplicate writes under a name minted inside the apply, so
+        // neither has anything addressable to sweep in either mode.
+        matches!(action, crate::state::OverwriteAction::Replace)
+    };
+    let mut apply = Box::pin(crate::sftp_helpers::apply_overwrite_for_item(
+        client.clone(),
+        item.clone(),
+        action,
+        temp_name,
+        Some(Arc::clone(counter)),
+    ));
+    let mut tick = tokio::time::interval(std::time::Duration::from_millis(120));
+    let finished = loop {
+        tokio::select! {
+            r = &mut apply => break r,
+            _ = tick.tick() => {
+                if sweepable && abort.load(Ordering::Relaxed) {
+                    // Same sweep rules as the plain upload path: which
+                    // side holds the bytes depends on the scratch-name
+                    // setting.
+                    drop(apply);
+                    if temp_name {
+                        client.discard_upload_scratch(&item.dst).await;
+                    } else {
+                        let _ = client.remove_file(&item.dst).await;
+                    }
+                    return Ok(WatchedApply::Aborted);
+                }
+                if !send(DropProgress::Advanced {
+                    transferred: completed + counter.load(Ordering::Relaxed),
+                })
+                .await
+                {
+                    return Ok(WatchedApply::ChannelClosed);
+                }
+            }
+        }
+    };
+    finished.map(|()| WatchedApply::Finished)
 }
 
 /// The pane whose last-drawn rect contains `point`. `None` when the

--- a/crates/oryxis-app/src/dispatch_terminal/drop.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/drop.rs
@@ -39,6 +39,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use iced::Task;
 use iced::futures::SinkExt;
+use iced::futures::future::BoxFuture;
 use uuid::Uuid;
 
 use crate::app::{Message, Oryxis, TerminalMessage, ZmodemMessage};
@@ -223,10 +224,11 @@ impl Oryxis {
 
     /// Start the SFTP half: pre-walk the sources (so the total is known
     /// up front), then upload sequentially on a fresh subsystem channel,
-    /// streaming progress back as messages. Top-level entries get
-    /// collision-free names via `unique_name_in_remote_dir`, the same
-    /// never-clobber rule the SFTP panel's folder upload uses; children
-    /// live under a fresh root, so they cannot conflict.
+    /// streaming progress back as messages. Top-level folders get
+    /// collision-free names via `unique_name_in_remote_dir` (a tree
+    /// cannot merge safely); top-level files keep their own name, and a
+    /// pre-existing destination pauses the upload to ask the user via
+    /// the overwrite modal instead of clobbering or silently renaming.
     fn begin_drop_sftp_upload(
         &mut self,
         pane_id: Uuid,
@@ -247,6 +249,7 @@ impl Oryxis {
                 total: None,
                 abort: Arc::clone(&abort),
                 dest_dir: dest_dir.clone(),
+                paused: None,
             });
         } else {
             return Task::none();
@@ -257,10 +260,10 @@ impl Oryxis {
             move |out: iced::futures::channel::mpsc::Sender<Message>| async move {
                 // Every exit path reports exactly one terminal event;
                 // the handler clears the card and toasts from it.
-                let send = |p: DropProgress| {
+                let send = |p: DropProgress| -> BoxFuture<'static, bool> {
                     let msg = Message::Terminal(TerminalMessage::TerminalDropProgress(pane_id, p));
                     let mut out = out.clone();
-                    async move { out.send(msg).await.is_ok() }
+                    Box::pin(async move { out.send(msg).await.is_ok() })
                 };
 
                 let client = match ssh.open_sftp().await {
@@ -271,9 +274,13 @@ impl Oryxis {
                     }
                 };
 
-                // Top-level plan: (source, unique remote destination,
-                // is_dir), then the recursive queue per folder.
-                let mut entries: Vec<(PathBuf, String, bool)> = Vec::new();
+                // Top-level plan: folders keep a non-colliding remote name
+                // (a tree cannot merge safely), files keep their own so a
+                // pre-existing destination asks the user instead of being
+                // silently renamed or overwritten. The run loop below does
+                // that per-file conflict check.
+                let mut plans: Vec<(String, Vec<crate::state::TransferItem>)> = Vec::new();
+                let mut total: u64 = 0;
                 for (src, is_dir) in files
                     .iter()
                     .map(|f| (f.clone(), false))
@@ -283,34 +290,21 @@ impl Oryxis {
                     else {
                         continue;
                     };
-                    let unique = match crate::sftp_helpers::unique_name_in_remote_dir(
-                        &client, &dest_dir, &base,
-                    )
-                    .await
-                    {
-                        Ok(u) => u,
-                        Err(e) => {
-                            send(DropProgress::Failed(e)).await;
-                            return;
-                        }
-                    };
-                    let dst = crate::sftp_helpers::remote_join(&dest_dir, &unique);
-                    entries.push((src, dst, is_dir));
-                }
-                if entries.is_empty() {
-                    send(DropProgress::Done).await;
-                    return;
-                }
-
-                // Expand folders into their full item queues now, so the
-                // byte total covers everything before the first write.
-                // (top-level display name, items in parent-first order)
-                let mut plans: Vec<(String, Vec<crate::state::TransferItem>)> = Vec::new();
-                let mut total: u64 = 0;
-                for (src, dst, is_dir) in entries {
-                    let name = dst.rsplit('/').next().unwrap_or(&dst).to_string();
-                    let mut items = Vec::new();
                     if is_dir {
+                        let unique = match crate::sftp_helpers::unique_name_in_remote_dir(
+                            &client, &dest_dir, &base,
+                        )
+                        .await
+                        {
+                            Ok(u) => u,
+                            Err(e) => {
+                                send(DropProgress::Failed(e)).await;
+                                return;
+                            }
+                        };
+                        let dst = crate::sftp_helpers::remote_join(&dest_dir, &unique);
+                        let name = dst.rsplit('/').next().unwrap_or(&dst).to_string();
+                        let mut items = Vec::new();
                         items.push(crate::state::TransferItem {
                             src: src.to_string_lossy().into_owned(),
                             dst: dst.clone(),
@@ -326,112 +320,151 @@ impl Oryxis {
                         }
                         total += queue.iter().filter_map(|i| i.size).sum::<u64>();
                         items.extend(queue);
+                        plans.push((name, items));
                     } else {
+                        let dst = crate::sftp_helpers::remote_join(&dest_dir, &base);
                         let size = tokio::fs::metadata(&src).await.map(|m| m.len()).ok();
                         total += size.unwrap_or(0);
-                        items.push(crate::state::TransferItem {
-                            src: src.to_string_lossy().into_owned(),
-                            dst,
-                            is_dir: false,
-                            size,
-                        });
+                        plans.push((
+                            base,
+                            vec![crate::state::TransferItem {
+                                src: src.to_string_lossy().into_owned(),
+                                dst,
+                                is_dir: false,
+                                size,
+                            }],
+                        ));
                     }
-                    plans.push((name, items));
+                }
+                if plans.is_empty() {
+                    send(DropProgress::Done).await;
+                    return;
                 }
                 if !send(DropProgress::Plan { total }).await {
                     return;
                 }
 
                 let of = plans.len();
-                let mut completed: u64 = 0;
-                for (index, (name, items)) in plans.into_iter().enumerate() {
-                    if !send(DropProgress::Entry {
-                        name,
-                        index: index + 1,
-                        of,
-                    })
-                    .await
-                    {
+                run_drop_upload_plans(
+                    &send,
+                    &client,
+                    temp_name,
+                    abort,
+                    pane_id,
+                    plans,
+                    0,
+                    of,
+                    0,
+                    dest_dir,
+                    None,
+                )
+                .await;
+            },
+        );
+        Task::stream(stream)
+    }
+
+    /// Apply the user's overwrite answer to a paused drop upload and
+    /// resume it from where it stopped. Called by the SFTP conflict
+    /// handler when the modal's prompt carried `drop_upload_pane`.
+    pub(crate) fn resolve_terminal_drop_conflict(
+        &mut self,
+        pane_id: Uuid,
+        action: crate::state::OverwriteAction,
+        apply_to_all: bool,
+    ) -> Task<Message> {
+        let Some(pane) = self.pane_by_id_mut(pane_id) else {
+            return Task::none();
+        };
+        let Some(up) = pane.drop_upload.as_mut() else {
+            return Task::none();
+        };
+        let Some(paused) = up.paused.take() else {
+            return Task::none();
+        };
+        let abort = up.abort.clone();
+        let Some(ssh) = pane.session.as_ref().and_then(|t| t.ssh()) else {
+            return Task::none();
+        };
+        let ssh = Arc::clone(ssh);
+        let crate::state::DropUploadPaused {
+            mut plans,
+            completed,
+            index,
+            of,
+            dest_dir,
+            temp_name,
+        } = paused;
+        let entry_start = index;
+        // Sticky answer when the user ticked "apply to all": every later
+        // conflict applies it instead of asking again.
+        let sticky = apply_to_all.then_some(action);
+        // The first remaining item is the conflicted file; pop it so the
+        // answer can be applied before the loop resumes.
+        let conflict = plans
+            .first_mut()
+            .and_then(|(_, items)| if items.is_empty() { None } else { Some(items.remove(0)) });
+
+        let stream = iced::stream::channel::<Message>(
+            64,
+            move |out: iced::futures::channel::mpsc::Sender<Message>| async move {
+                let send = |p: DropProgress| -> BoxFuture<'static, bool> {
+                    let msg = Message::Terminal(TerminalMessage::TerminalDropProgress(pane_id, p));
+                    let mut out = out.clone();
+                    Box::pin(async move { out.send(msg).await.is_ok() })
+                };
+
+                // Cancelled via the overlay while the modal was up:
+                // honor it instead of starting the paused upload.
+                if abort.load(Ordering::Relaxed) {
+                    send(DropProgress::Cancelled).await;
+                    return;
+                }
+
+                let client = match ssh.open_sftp().await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        send(DropProgress::Failed(e.to_string())).await;
                         return;
                     }
-                    for item in items {
-                        if abort.load(Ordering::Relaxed) {
-                            send(DropProgress::Cancelled).await;
-                            return;
-                        }
-                        if item.is_dir {
-                            // Merge-tolerant like the panel's uploader: a
-                            // racing mkdir is fine, anything else poisons
-                            // every child below it, so surface it now.
-                            if let Err(e) = client.create_dir(&item.dst).await
-                                && client.list_dir(&item.dst).await.is_err()
-                            {
-                                send(DropProgress::Failed(e.to_string())).await;
-                                return;
-                            }
-                            continue;
-                        }
+                };
+
+                let mut completed = completed;
+                if let Some(item) = conflict {
+                    if !matches!(action, crate::state::OverwriteAction::Cancel) {
                         let counter = Arc::new(AtomicU64::new(0));
-                        let src = PathBuf::from(&item.src);
-                        let mut up = Box::pin(crate::sftp_helpers::upload_one(
-                            &client,
-                            &src,
-                            &item.dst,
+                        if let Err(e) = crate::sftp_helpers::apply_overwrite_for_item(
+                            client.clone(),
+                            item,
+                            action,
                             temp_name,
                             Some(Arc::clone(&counter)),
-                        ));
-                        let mut tick =
-                            tokio::time::interval(std::time::Duration::from_millis(120));
-                        let finished = loop {
-                            tokio::select! {
-                                r = &mut up => break r,
-                                _ = tick.tick() => {
-                                    if abort.load(Ordering::Relaxed) {
-                                        // Kill the in-flight write and
-                                        // sweep the partial so a cancel
-                                        // never masquerades as a
-                                        // complete file. Which path holds
-                                        // the bytes depends on the
-                                        // scratch-name setting: with it
-                                        // on they went to `<dst>.oryxis-
-                                        // part`, so removing `dst` would
-                                        // miss the scratch AND could
-                                        // delete a pre-existing real file
-                                        // this upload never touched.
-                                        drop(up);
-                                        if temp_name {
-                                            client.discard_upload_scratch(&item.dst).await;
-                                        } else {
-                                            let _ = client.remove_file(&item.dst).await;
-                                        }
-                                        send(DropProgress::Cancelled).await;
-                                        return;
-                                    }
-                                    if !send(DropProgress::Advanced {
-                                        transferred: completed + counter.load(Ordering::Relaxed),
-                                    })
-                                    .await
-                                    {
-                                        return;
-                                    }
-                                }
-                            }
-                        };
-                        if let Err(e) = finished {
-                            send(DropProgress::Failed(format!("{}: {e}", item.dst))).await;
-                            return;
-                        }
-                        completed += item.size.unwrap_or_else(|| counter.load(Ordering::Relaxed));
-                        if !send(DropProgress::Advanced {
-                            transferred: completed,
-                        })
+                        )
                         .await
                         {
+                            send(DropProgress::Failed(e)).await;
+                            return;
+                        }
+                        completed += counter.load(Ordering::Relaxed);
+                        if !send(DropProgress::Advanced { transferred: completed }).await {
                             return;
                         }
                     }
                 }
-                send(DropProgress::Done).await;
+                run_drop_upload_plans(
+                    &send,
+                    &client,
+                    temp_name,
+                    abort,
+                    pane_id,
+                    plans,
+                    completed,
+                    of,
+                    entry_start,
+                    dest_dir,
+                    sticky,
+                )
+                .await;
             },
         );
         Task::stream(stream)
@@ -449,6 +482,10 @@ impl Oryxis {
         // Title + body for the OS notice on a terminal event, taken
         // while the card is still here (the arms below consume it).
         let mut finished: Option<(String, String)> = None;
+        // A `Conflict` parks the paused context on the pane and raises
+        // the overwrite modal; the modal write happens after the pane
+        // borrow below ends.
+        let mut park_prompt: Option<crate::state::OverwritePrompt> = None;
         if let Some(pane) = self.pane_by_id_mut(pane_id) {
             let file_name = pane
                 .drop_upload
@@ -473,6 +510,13 @@ impl Oryxis {
                     if let Some(up) = pane.drop_upload.as_mut() {
                         up.transferred = transferred;
                     }
+                }
+                DropProgress::Conflict { prompt, item, paused } => {
+                    if let Some(up) = pane.drop_upload.as_mut() {
+                        up.paused = Some(paused);
+                        up.file_name = Some(crate::sftp_helpers::transfer_item_label(&item));
+                    }
+                    park_prompt = Some(prompt);
                 }
                 DropProgress::Done => {
                     let up = pane.drop_upload.take();
@@ -515,6 +559,13 @@ impl Oryxis {
                 }
             }
         }
+        // A destination conflict paused the drop upload: raise the
+        // overwrite modal. The pane keeps the paused context; answering
+        // the modal resumes the upload through
+        // `resolve_terminal_drop_conflict`.
+        if let Some(prompt) = park_prompt {
+            self.sftp.overwrite_prompt = Some(prompt);
+        }
         // Dropping files onto the terminal is an upload like any other,
         // and the one most likely to be left running: the user dropped
         // a folder and went back to what they were doing. Away from the
@@ -530,6 +581,192 @@ impl Oryxis {
         }
         refresh.unwrap_or_else(Task::none)
     }
+}
+
+/// Drive the upload loop shared by the initial drop
+/// (`begin_drop_sftp_upload`) and a paused-then-resumed one
+/// (`resolve_terminal_drop_conflict`).
+///
+/// Every file item checks its destination first: a pre-existing file with
+/// no sticky default pauses the whole drop (emitting `Conflict`, which the
+/// update loop turns into the overwrite modal) instead of overwriting
+/// silently. Folders merge tolerantly, mirroring the panel uploader.
+#[allow(clippy::too_many_arguments)]
+async fn run_drop_upload_plans(
+    send: &(dyn Fn(DropProgress) -> BoxFuture<'static, bool> + Send + Sync),
+    client: &oryxis_ssh::SftpClient,
+    temp_name: bool,
+    abort: Arc<AtomicBool>,
+    pane_id: Uuid,
+    plans: Vec<(String, Vec<crate::state::TransferItem>)>,
+    mut completed: u64,
+    of: usize,
+    entry_start: usize,
+    dest_dir: String,
+    overwrite_default: Option<crate::state::OverwriteAction>,
+) {
+    for (plan_idx, (name, plan_items)) in plans.iter().enumerate() {
+        let index = entry_start + plan_idx + 1;
+        if !send(DropProgress::Entry {
+            name: name.clone(),
+            index,
+            of,
+        })
+        .await
+        {
+            return;
+        }
+        let item_count = plan_items.len();
+        for item_idx in 0..item_count {
+            let item = &plan_items[item_idx];
+            if abort.load(Ordering::Relaxed) {
+                send(DropProgress::Cancelled).await;
+                return;
+            }
+            if item.is_dir {
+                // Merge-tolerant like the panel's uploader: a racing mkdir
+                // is fine, anything else poisons every child below it, so
+                // surface it now.
+                if let Err(e) = client.create_dir(&item.dst).await
+                    && client.list_dir(&item.dst).await.is_err()
+                {
+                    send(DropProgress::Failed(e.to_string())).await;
+                    return;
+                }
+                continue;
+            }
+            // Conflict gate: a pre-existing destination asks instead of
+            // silently overwriting (or silently renaming, the old drop
+            // behavior). Mirrors the panel queue's per-item check.
+            let parent = crate::sftp_helpers::parent_path(&item.dst);
+            let basename = item
+                .dst
+                .rsplit('/')
+                .find(|s| !s.is_empty())
+                .unwrap_or(&item.dst)
+                .to_string();
+            let entries = match client.list_dir(&parent).await {
+                Ok(e) => e,
+                Err(e) => {
+                    send(DropProgress::Failed(e.to_string())).await;
+                    return;
+                }
+            };
+            if let Some(existing) = entries.iter().find(|e| e.name == basename) {
+                if let Some(action) = overwrite_default {
+                    let counter = Arc::new(AtomicU64::new(0));
+                    if let Err(e) = crate::sftp_helpers::apply_overwrite_for_item(
+                        client.clone(),
+                        item.clone(),
+                        action,
+                        temp_name,
+                        Some(Arc::clone(&counter)),
+                    )
+                    .await
+                    {
+                        send(DropProgress::Failed(e)).await;
+                        return;
+                    }
+                    completed += counter.load(Ordering::Relaxed);
+                    if !send(DropProgress::Advanced { transferred: completed }).await {
+                        return;
+                    }
+                    continue;
+                }
+                let src_size = tokio::fs::metadata(&item.src)
+                    .await
+                    .map(|m| m.len())
+                    .unwrap_or(0);
+                let prompt = crate::state::OverwritePrompt {
+                    dst_dir: parent,
+                    basename,
+                    src_size,
+                    dst_size: existing.size,
+                    direction: crate::state::OverwriteDirection::Upload,
+                    multi: of > 1,
+                    apply_to_all: false,
+                    owner: None,
+                    drop_upload_pane: Some(pane_id),
+                };
+                // Everything still to do, this conflicted item first, so
+                // the resolve handler can apply the answer and continue.
+                let mut rest: Vec<(String, Vec<crate::state::TransferItem>)> = Vec::new();
+                rest.push((name.clone(), plan_items[item_idx..].to_vec()));
+                for (pname, pitems) in plans.iter().skip(plan_idx + 1) {
+                    rest.push((pname.clone(), pitems.clone()));
+                }
+                send(DropProgress::Conflict {
+                    prompt,
+                    item: item.clone(),
+                    paused: crate::state::DropUploadPaused {
+                        plans: rest,
+                        completed,
+                        // 0-based global entry position; the resume uses
+                        // it as its `entry_start` so the displayed
+                        // `(k, n)` batch position does not advance twice.
+                        index: entry_start + plan_idx,
+                        of,
+                        dest_dir: dest_dir.clone(),
+                        temp_name,
+                    },
+                })
+                .await;
+                return;
+            }
+            // No conflict: upload with progress ticks.
+            let counter = Arc::new(AtomicU64::new(0));
+            let src = PathBuf::from(&item.src);
+            let mut up = Box::pin(crate::sftp_helpers::upload_one(
+                client,
+                &src,
+                &item.dst,
+                temp_name,
+                Some(Arc::clone(&counter)),
+            ));
+            let mut tick = tokio::time::interval(std::time::Duration::from_millis(120));
+            let finished = loop {
+                tokio::select! {
+                    r = &mut up => break r,
+                    _ = tick.tick() => {
+                        if abort.load(Ordering::Relaxed) {
+                            // Kill the in-flight write and sweep the
+                            // partial so a cancel never masquerades as a
+                            // complete file. Which path holds the bytes
+                            // depends on the scratch-name setting: with it
+                            // on they went to `<dst>.oryxis-part`, so
+                            // removing `dst` would miss the scratch AND
+                            // could delete a pre-existing real file this
+                            // upload never touched.
+                            drop(up);
+                            if temp_name {
+                                client.discard_upload_scratch(&item.dst).await;
+                            } else {
+                                let _ = client.remove_file(&item.dst).await;
+                            }
+                            send(DropProgress::Cancelled).await;
+                            return;
+                        }
+                        if !send(DropProgress::Advanced {
+                            transferred: completed + counter.load(Ordering::Relaxed),
+                        })
+                        .await
+                        {
+                            return;
+                        }
+                    }
+                }
+            };
+            if let Err(e) = finished {
+                send(DropProgress::Failed(format!("{}: {e}", item.dst))).await;
+                return;
+            }
+            completed += item.size.unwrap_or_else(|| counter.load(Ordering::Relaxed));
+            if !send(DropProgress::Advanced { transferred: completed }).await {
+                return;
+            }
+        }
+    }
+    send(DropProgress::Done).await;
 }
 
 /// The pane whose last-drawn rect contains `point`. `None` when the

--- a/crates/oryxis-app/src/dispatch_terminal/drop.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/drop.rs
@@ -430,25 +430,25 @@ impl Oryxis {
                 };
 
                 let mut completed = completed;
-                if let Some(item) = conflict {
-                    if !matches!(action, crate::state::OverwriteAction::Cancel) {
-                        let counter = Arc::new(AtomicU64::new(0));
-                        if let Err(e) = crate::sftp_helpers::apply_overwrite_for_item(
-                            client.clone(),
-                            item,
-                            action,
-                            temp_name,
-                            Some(Arc::clone(&counter)),
-                        )
-                        .await
-                        {
-                            send(DropProgress::Failed(e)).await;
-                            return;
-                        }
-                        completed += counter.load(Ordering::Relaxed);
-                        if !send(DropProgress::Advanced { transferred: completed }).await {
-                            return;
-                        }
+                if let Some(item) = conflict
+                    && !matches!(action, crate::state::OverwriteAction::Cancel)
+                {
+                    let counter = Arc::new(AtomicU64::new(0));
+                    if let Err(e) = crate::sftp_helpers::apply_overwrite_for_item(
+                        client.clone(),
+                        item,
+                        action,
+                        temp_name,
+                        Some(Arc::clone(&counter)),
+                    )
+                    .await
+                    {
+                        send(DropProgress::Failed(e)).await;
+                        return;
+                    }
+                    completed += counter.load(Ordering::Relaxed);
+                    if !send(DropProgress::Advanced { transferred: completed }).await {
+                        return;
                     }
                 }
                 run_drop_upload_plans(
@@ -516,7 +516,7 @@ impl Oryxis {
                         up.paused = Some(paused);
                         up.file_name = Some(crate::sftp_helpers::transfer_item_label(&item));
                     }
-                    park_prompt = Some(prompt);
+                    park_prompt = Some(*prompt);
                 }
                 DropProgress::Done => {
                     let up = pane.drop_upload.take();
@@ -696,7 +696,7 @@ async fn run_drop_upload_plans(
                     rest.push((pname.clone(), pitems.clone()));
                 }
                 send(DropProgress::Conflict {
-                    prompt,
+                    prompt: Box::new(prompt),
                     item: item.clone(),
                     paused: crate::state::DropUploadPaused {
                         plans: rest,

--- a/crates/oryxis-app/src/sftp_helpers.rs
+++ b/crates/oryxis-app/src/sftp_helpers.rs
@@ -575,6 +575,7 @@ pub(crate) async fn do_upload_item(
             multi,
             apply_to_all: false,
                     owner: None,
+                    drop_upload_pane: None,
         };
         return Ok(TransferStepOutcome::Conflict { prompt, item });
     }
@@ -709,6 +710,7 @@ pub(crate) async fn do_download_item(
             multi,
             apply_to_all: false,
                     owner: None,
+                    drop_upload_pane: None,
         };
         return Ok(TransferStepOutcome::Conflict { prompt, item });
     }

--- a/crates/oryxis-app/src/sftp_methods.rs
+++ b/crates/oryxis-app/src/sftp_methods.rs
@@ -1551,8 +1551,10 @@ fn list_wsl_distros_for_pane() -> Vec<String> {
         // wsl.exe emits UTF-16LE on stdout when invoked from Win32.
         let bytes = output.stdout;
         let utf16: Vec<u16> = bytes
-            .chunks_exact(2)
-            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| u16::from_le_bytes(*c))
             .collect();
         let text = String::from_utf16_lossy(&utf16);
         text.lines()

--- a/crates/oryxis-app/src/state/sftp.rs
+++ b/crates/oryxis-app/src/state/sftp.rs
@@ -746,6 +746,12 @@ pub(crate) struct OverwritePrompt {
     /// bar frozen. `None` only for prompts built before this field
     /// existed in a given flow; those fall back to the live buffer.
     pub owner: Option<uuid::Uuid>,
+    /// When set, the conflict came from a terminal / sidebar Files drop
+    /// upload (`begin_drop_sftp_upload`) on this pane, and resolving it
+    /// resumes that upload instead of a transfer queue. The modal's
+    /// answer stays unaddressed (`owner: None`) so it lands in the
+    /// plain SFTP handler, which dispatches on this field.
+    pub drop_upload_pane: Option<uuid::Uuid>,
 }
 
 impl OverwritePrompt {

--- a/crates/oryxis-app/src/state/tabs/pane.rs
+++ b/crates/oryxis-app/src/state/tabs/pane.rs
@@ -748,6 +748,31 @@ pub(crate) struct DropUploadPane {
     /// the sidebar Files browser when it is showing this directory, so
     /// the uploaded entries appear without a manual refresh.
     pub dest_dir: String,
+    /// Context parked while a destination conflict paused the upload
+    /// and the overwrite modal is up; the resolve handler resumes the
+    /// upload with it once the user answers.
+    pub paused: Option<DropUploadPaused>,
+}
+
+/// Everything the resume handler needs to continue a drop upload after
+/// the user answered an overwrite prompt. The SFTP client is NOT kept:
+/// it is re-opened from the pane's live session on resume, so this stays
+/// `Debug + Clone` (it rides `DropProgress`).
+#[derive(Debug, Clone)]
+pub(crate) struct DropUploadPaused {
+    /// Remaining top-level plans; the first entry's first item is the
+    /// conflicted file the answer applies to.
+    pub plans: Vec<(String, Vec<crate::state::TransferItem>)>,
+    /// Bytes already transferred before the pause.
+    pub completed: u64,
+    /// 0-based position of the paused entry across the whole drop, so
+    /// the resume keeps the same displayed `(k, n)` batch position.
+    pub index: usize,
+    pub of: usize,
+    /// Remote directory the drop lands in (kept so the resume stream
+    /// can refresh the sidebar Files browser at `Done`).
+    pub dest_dir: String,
+    pub temp_name: bool,
 }
 
 /// Progress events streamed by the OS-drop SFTP upload task
@@ -762,6 +787,14 @@ pub(crate) enum DropProgress {
     Entry { name: String, index: usize, of: usize },
     /// Cumulative bytes moved across the whole drop.
     Advanced { transferred: u64 },
+    /// A destination file already exists: the upload paused and the
+    /// overwrite modal is up. `paused` is what the resolve handler
+    /// resumes with once the user answers.
+    Conflict {
+        prompt: crate::state::OverwritePrompt,
+        item: crate::state::TransferItem,
+        paused: DropUploadPaused,
+    },
     Done,
     Failed(String),
     Cancelled,

--- a/crates/oryxis-app/src/state/tabs/pane.rs
+++ b/crates/oryxis-app/src/state/tabs/pane.rs
@@ -791,7 +791,7 @@ pub(crate) enum DropProgress {
     /// overwrite modal is up. `paused` is what the resolve handler
     /// resumes with once the user answers.
     Conflict {
-        prompt: crate::state::OverwritePrompt,
+        prompt: Box<crate::state::OverwritePrompt>,
         item: crate::state::TransferItem,
         paused: DropUploadPaused,
     },

--- a/crates/oryxis-app/src/state_tests.rs
+++ b/crates/oryxis-app/src/state_tests.rs
@@ -20,6 +20,7 @@ fn overwrite_sizes_follow_the_transfer_direction() {
         multi: false,
         apply_to_all: false,
         owner: None,
+        drop_upload_pane: None,
     };
     // Uploading: the source IS the local file.
     assert_eq!(


### PR DESCRIPTION
## Summary

Dropping files onto a terminal pane or the sidebar Files browser now routes through the same overwrite flow as the SFTP panel: when the destination already exists, the upload pauses and the conflict modal asks the user to Replace / Replace if different / Duplicate / Cancel, optionally applying the answer to the rest of the drop. Previously the drop silently renamed top-level files (via `unique_name_in_remote_dir`) or clobbered the existing file, with no way to choose.

## Changes

- `dispatch_terminal/drop.rs`: top-level files keep their own name instead of being auto-renamed; a pre-existing destination emits a new `DropProgress::Conflict` that pauses the upload. The upload loop was factored into a shared `run_drop_upload_plans` so an initial drop and a paused-then-resumed one run the same code. A new `resolve_terminal_drop_conflict` resumes the upload once the modal is answered.
- `state/tabs/pane.rs`: `DropUploadPane` gains a `paused` field; the new `DropUploadPaused` carries the remaining plans, byte progress and batch position; `DropProgress::Conflict` variant.
- `state/sftp.rs`: `OverwritePrompt` gains a `drop_upload_pane` field marking prompts raised by a drop upload.
- `dispatch_sftp_transfers/mod.rs`: answers to a drop-conflict modal are intercepted before the SFTP-owner gate (they must resolve even with no SFTP tab open) and dispatched to the pane's resume handler.
- `dispatch_sftp_transfers/conflict.rs`: stale drop conflicts are declined defensively.
- `sftp_helpers.rs`: queue-path prompts are stamped `drop_upload_pane: None`.

## Behavior

- Drop uploads of existing names now pause and ask instead of silently renaming or overwriting.
- Folder drops keep the collision-free rename for the folder itself (a tree cannot merge safely); files inside it participate in the same per-file conflict check.
- "Apply to all" answers stay sticky for the rest of the drop.
- Cancel skips only the conflicting file (or the rest of the drop when sticky); it never deletes the existing destination.
- Cancelling via the drop overlay while the modal is open is honored on resume.

## Testing

- `cargo check --offline` passes.
- Manually verified on Windows: dropping a same-named file over the terminal shows the modal; each answer (Replace / Duplicate / Cancel, with and without apply-to-all) resumes the upload correctly.