### PR TITLE
fix(sidebar): the Files rows answer Delete and Menu, with or without the ring

### DIFF
--- a/crates/oryxis-app/src/dispatch_keynav_sidebar.rs
+++ b/crates/oryxis-app/src/dispatch_keynav_sidebar.rs
@@ -33,7 +33,7 @@
 use iced::keyboard;
 use iced::Task;
 
-use crate::app::{AiMessage, Message, Oryxis};
+use crate::app::{AiMessage, Message, Oryxis, SidebarFilesMessage};
 use crate::keynav::movement::index_move;
 use crate::keynav::SidebarRow;
 use crate::state::TerminalSidebarTab;
@@ -152,6 +152,31 @@ impl Oryxis {
             .sidebar_tab_side(tab)
             .unwrap_or(crate::state::SidebarSide::Right);
         &self.keynav.sidebar_items[side.idx()]
+    }
+
+    /// The Files browser's mouse selection as a delete target
+    /// (`(full path, is_dir)`). `None` on any other tab, with no
+    /// selection, or when the selection no longer matches the listing
+    /// (a refresh raced the key): a stale selection must never guess
+    /// `is_dir`, so the key simply isn't consumed.
+    fn sidebar_files_selected_entry(
+        &self,
+        tab: TerminalSidebarTab,
+    ) -> Option<(String, bool)> {
+        if tab != TerminalSidebarTab::Files {
+            return None;
+        }
+        let pane = self.tabs.get(self.active_tab?)?.active();
+        let path = pane.files.selected.clone()?;
+        let is_dir = pane
+            .files
+            .entries
+            .iter()
+            .find(|e| {
+                crate::dispatch_sidebar_files::files_join(&pane.files.path, &e.name) == path
+            })?
+            .is_dir;
+        Some((path, is_dir))
     }
 
     /// Keep the selected row visible; same best-effort relative snap
@@ -500,13 +525,22 @@ impl Oryxis {
                 Some(self.update(msg))
             }
             Named::Delete => {
-                let idx = ring?;
-                let row = self.sidebar_items_for(tab).borrow().get(idx).cloned()?;
-                let msg = row.delete?;
-                // The recording shrinks next frame; the selection is
-                // clamped on the next key, so the ring lands on the
-                // neighbor instead of vanishing.
-                Some(self.update(msg))
+                if let Some(idx) = ring {
+                    let row = self.sidebar_items_for(tab).borrow().get(idx).cloned()?;
+                    let msg = row.delete?;
+                    // The recording shrinks next frame; the selection is
+                    // clamped on the next key, so the ring lands on the
+                    // neighbor instead of vanishing.
+                    return Some(self.update(msg));
+                }
+                // Files: a click selects a row AND deliberately drops the
+                // ring (`SidebarFilesSelectRow`), so a ring-less Del acts
+                // on what the mouse selected — the select-then-Del pair
+                // the SFTP pane offers.
+                let (path, is_dir) = self.sidebar_files_selected_entry(tab)?;
+                Some(self.update(Message::SidebarFiles(
+                    SidebarFilesMessage::SidebarFilesDelete(path, is_dir),
+                )))
             }
             Named::Escape => {
                 // Esc is the "give me the terminal back" key: drop the

--- a/crates/oryxis-app/src/dispatch_keynav_sidebar.rs
+++ b/crates/oryxis-app/src/dispatch_keynav_sidebar.rs
@@ -29,6 +29,14 @@
 //! receives text while the ring is up; the selection is tagged by
 //! sidebar tab and clamped against each frame's recording, so
 //! filtering while ringed just clamps.
+//!
+//! Delete has a second, RING-LESS reading, and only on Files: a click
+//! there selects a row and deliberately drops the ring, so the key
+//! falls back to the mouse selection (`sidebar_files_selected_entry`),
+//! which is the select-then-Del pair the SFTP pane offers. That
+//! fallback is what makes the inline-edit guard in that helper load
+//! bearing: this layer engages on the cursor alone, so a Delete typed
+//! into a Files input must not reach a file.
 
 use iced::keyboard;
 use iced::Task;
@@ -159,6 +167,18 @@ impl Oryxis {
     /// selection, or when the selection no longer matches the listing
     /// (a refresh raced the key): a stale selection must never guess
     /// `is_dir`, so the key simply isn't consumed.
+    ///
+    /// Also `None` while an inline edit (path / rename / new entry)
+    /// owns the keyboard, which is the SFTP pane's `editing` guard
+    /// under another name. This layer engages on the CURSOR being
+    /// over the sidebar, and the ring goes quiet on an input row, so
+    /// without it a Delete meant to erase a character forward inside
+    /// the rename field would raise the destructive confirm on the
+    /// row the mouse selected earlier, with the removal as its
+    /// default button: the next Enter, the one that was going to
+    /// commit the rename, would delete the file instead. The refusal
+    /// lives HERE rather than in the Delete arm so a later ring-less
+    /// caller (the Menu key is the obvious one) inherits it.
     fn sidebar_files_selected_entry(
         &self,
         tab: TerminalSidebarTab,
@@ -167,6 +187,12 @@ impl Oryxis {
             return None;
         }
         let pane = self.tabs.get(self.active_tab?)?.active();
+        if pane.files.path_editing.is_some()
+            || pane.files.rename.is_some()
+            || pane.files.new_entry.is_some()
+        {
+            return None;
+        }
         let path = pane.files.selected.clone()?;
         let is_dir = pane
             .files
@@ -535,7 +561,7 @@ impl Oryxis {
                 }
                 // Files: a click selects a row AND deliberately drops the
                 // ring (`SidebarFilesSelectRow`), so a ring-less Del acts
-                // on what the mouse selected — the select-then-Del pair
+                // on what the mouse selected, the select-then-Del pair
                 // the SFTP pane offers.
                 let (path, is_dir) = self.sidebar_files_selected_entry(tab)?;
                 Some(self.update(Message::SidebarFiles(

--- a/crates/oryxis-app/src/keynav/slots.rs
+++ b/crates/oryxis-app/src/keynav/slots.rs
@@ -164,6 +164,14 @@ impl SidebarRow {
         self
     }
 
+    /// Attach the row's delete verb, so the Delete key reaches what
+    /// the row's context menu reaches (a list row whose remove action
+    /// only lives behind right-click is mouse-only without this).
+    pub(crate) fn with_delete(mut self, msg: Message) -> Self {
+        self.delete = Some(msg);
+        self
+    }
+
     /// Mark this row as the surface's current mouse selection, the
     /// arrow hover-entry's preferred landing spot.
     pub(crate) fn with_anchor(mut self, anchor: bool) -> Self {

--- a/crates/oryxis-app/src/views/sidebar_files.rs
+++ b/crates/oryxis-app/src/views/sidebar_files.rs
@@ -585,8 +585,24 @@ impl Oryxis {
                 .on_right_press(Message::SidebarFiles(SidebarFilesMessage::ShowSidebarFilesRowMenu(full.clone(), is_dir)));
         }
 
+        // The keyboard half of the right-click: Delete asks about the
+        // row (through the shared confirm dialog, same rule as the
+        // Snippets / History rows) and the Menu key opens the same
+        // context menu. The ".." row carries neither.
+        let mut row = crate::keynav::SidebarRow::list_button(key_activate).with_anchor(selected);
+        if let Some(full) = &full_path {
+            row = row
+                .with_delete(Message::SidebarFiles(SidebarFilesMessage::SidebarFilesDelete(
+                    full.clone(),
+                    is_dir,
+                )))
+                .with_menu(Message::SidebarFiles(SidebarFilesMessage::ShowSidebarFilesRowMenu(
+                    full.clone(),
+                    is_dir,
+                )));
+        }
         self.sidebar_nav_slot(
-            crate::keynav::SidebarRow::list_button(key_activate).with_anchor(selected),
+            row,
             TerminalSidebarTab::Files,
             6.0,
             area.into(),


### PR DESCRIPTION
**Reported.** Pressing Del on a file row in the sidebar Files tab did nothing, while the SFTP panel deleted fine.

**Root cause.** The delete pipeline was already complete (right-click menu → confirm dialog → remove); the keyboard simply never reached it. Files rows were recorded as plain list-button keynav slots carrying no `delete` / `menu` verb, so the sidebar Delete arm had nothing to fire. Snippets / History rows record their delete verb, which is why those tabs worked.

**Fix.**
- File rows now record `delete` (through the same confirm dialog the menu uses) and `menu` (the right-click menu); the `..` row keeps neither.
- A click selects a row AND deliberately drops the keynav ring, so a ring-less Del also falls back to the mouse selection — the select-then-Del pair the SFTP panel offers. The selection is resolved through the listing (`is_dir` included); a stale selection declines the key instead of guessing.

**Verify.** Click a file row, press Del, confirm — or arrow onto a row and press Del.

**Quality gates.**
- `cargo check --workspace` ✓
- `cargo test --workspace --lib --bins` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
