### PR TITLE
feat(sidebar): multi-select with bulk copy, delete and download in the Files browser

### DIFF
--- a/crates/oryxis-app/src/dispatch_keynav_sidebar.rs
+++ b/crates/oryxis-app/src/dispatch_keynav_sidebar.rs
@@ -345,21 +345,26 @@ impl Oryxis {
             && !modifiers.alt()
             && matches!(key, keyboard::Key::Character(c) if c.as_str().eq_ignore_ascii_case("a"))
         {
-            if let Some(idx) = self.active_tab
-                && let Some(t) = self.tabs.get_mut(idx)
+            let idx = self.active_tab?;
+            let files = &mut self.tabs.get_mut(idx)?.active_mut().files;
+            // DECLINE rather than consume while an inline edit owns the
+            // keyboard: there Ctrl+A is the text input's own select-all,
+            // and swallowing it here would leave the field with a key
+            // that does nothing. Same reason the ring-less Delete
+            // refuses in `sidebar_files_selected_entries`, and the same
+            // shape: not acting is not the same as consuming.
+            if files.path_editing.is_some()
+                || files.rename.is_some()
+                || files.new_entry.is_some()
             {
-                let files = &mut t.active_mut().files;
-                if files.path_editing.is_none()
-                    && files.rename.is_none()
-                    && files.new_entry.is_none()
-                {
-                    let paths = crate::dispatch_sidebar_files::visible_entry_paths(files);
-                    if !paths.is_empty() {
-                        files.selection_anchor = Some(paths[0].clone());
-                        files.selected = paths;
-                    }
-                }
+                return None;
             }
+            let paths = crate::dispatch_sidebar_files::visible_entry_paths(files);
+            if paths.is_empty() {
+                return None;
+            }
+            files.selection_anchor = Some(paths[0].clone());
+            files.selected = paths;
             return Some(Task::none());
         }
         if modifiers.control() || modifiers.alt() || modifiers.logo() {

--- a/crates/oryxis-app/src/dispatch_keynav_sidebar.rs
+++ b/crates/oryxis-app/src/dispatch_keynav_sidebar.rs
@@ -32,11 +32,12 @@
 //!
 //! Delete has a second, RING-LESS reading, and only on Files: a click
 //! there selects a row and deliberately drops the ring, so the key
-//! falls back to the mouse selection (`sidebar_files_selected_entry`),
-//! which is the select-then-Del pair the SFTP pane offers. That
-//! fallback is what makes the inline-edit guard in that helper load
-//! bearing: this layer engages on the cursor alone, so a Delete typed
-//! into a Files input must not reach a file.
+//! falls back to the mouse selection
+//! (`sidebar_files_selected_entries`, the whole multi-selection), which
+//! is the select-then-Del pair the SFTP pane offers. That fallback is
+//! what makes the inline-edit guard in that helper load bearing: this
+//! layer engages on the cursor alone, so a Delete typed into a Files
+//! input must not reach a file.
 
 use iced::keyboard;
 use iced::Task;
@@ -162,27 +163,27 @@ impl Oryxis {
         &self.keynav.sidebar_items[side.idx()]
     }
 
-    /// The Files browser's mouse selection as a delete target
-    /// (`(full path, is_dir)`). `None` on any other tab, with no
-    /// selection, or when the selection no longer matches the listing
-    /// (a refresh raced the key): a stale selection must never guess
-    /// `is_dir`, so the key simply isn't consumed.
-    ///
-    /// Also `None` while an inline edit (path / rename / new entry)
-    /// owns the keyboard, which is the SFTP pane's `editing` guard
-    /// under another name. This layer engages on the CURSOR being
-    /// over the sidebar, and the ring goes quiet on an input row, so
-    /// without it a Delete meant to erase a character forward inside
-    /// the rename field would raise the destructive confirm on the
-    /// row the mouse selected earlier, with the removal as its
-    /// default button: the next Enter, the one that was going to
-    /// commit the rename, would delete the file instead. The refusal
-    /// lives HERE rather than in the Delete arm so a later ring-less
-    /// caller (the Menu key is the obvious one) inherits it.
-    fn sidebar_files_selected_entry(
+    /// The Files browser's mouse selection as delete targets
+    /// (`(full path, is_dir)` pairs, in listing order). `None` on any
+    /// other tab, with no selection, or when the selection no longer
+    /// matches the listing (a refresh raced the key): a stale
+    /// selection must never guess `is_dir`, so the key simply isn't
+    /// consumed. Also `None` while an inline edit (path / rename /
+    /// new entry) owns the keyboard, which is the SFTP pane's
+    /// `editing` guard under another name. This layer engages on the
+    /// CURSOR being over the sidebar, and the ring goes quiet on an
+    /// input row, so without it a Delete meant to erase a character
+    /// forward inside the rename field would raise the destructive
+    /// confirm on the rows the mouse selected earlier, with the
+    /// removal as its default button: the next Enter, the one that
+    /// was going to commit the rename, would delete the files
+    /// instead. The refusal lives HERE rather than in the Delete arm
+    /// so a later ring-less caller (the Menu key is the obvious one)
+    /// inherits it.
+    fn sidebar_files_selected_entries(
         &self,
         tab: TerminalSidebarTab,
-    ) -> Option<(String, bool)> {
+    ) -> Option<Vec<(String, bool)>> {
         if tab != TerminalSidebarTab::Files {
             return None;
         }
@@ -193,16 +194,8 @@ impl Oryxis {
         {
             return None;
         }
-        let path = pane.files.selected.clone()?;
-        let is_dir = pane
-            .files
-            .entries
-            .iter()
-            .find(|e| {
-                crate::dispatch_sidebar_files::files_join(&pane.files.path, &e.name) == path
-            })?
-            .is_dir;
-        Some((path, is_dir))
+        let selected = crate::dispatch_sidebar_files::selected_items(&pane.files);
+        (!selected.is_empty()).then_some(selected)
     }
 
     /// Keep the selected row visible; same best-effort relative snap
@@ -339,6 +332,35 @@ impl Oryxis {
                 // No search on Chat / Host config.
                 _ => return None,
             }
+        }
+        // Ctrl+A / Cmd+A on the Files tab: select every visible row,
+        // anchored on the first so a follow-up shift-click keeps
+        // well-defined semantics (the SFTP pane's rule). An inline
+        // edit (path / rename / new entry) owns the key: there it is
+        // the input's own select-all. Gated on the same sidebar
+        // engagement as everything here, so a Ctrl+A meant for the
+        // terminal (readline line-start) is never stolen.
+        if tab == TerminalSidebarTab::Files
+            && (modifiers.control() || modifiers.command())
+            && !modifiers.alt()
+            && matches!(key, keyboard::Key::Character(c) if c.as_str().eq_ignore_ascii_case("a"))
+        {
+            if let Some(idx) = self.active_tab
+                && let Some(t) = self.tabs.get_mut(idx)
+            {
+                let files = &mut t.active_mut().files;
+                if files.path_editing.is_none()
+                    && files.rename.is_none()
+                    && files.new_entry.is_none()
+                {
+                    let paths = crate::dispatch_sidebar_files::visible_entry_paths(files);
+                    if !paths.is_empty() {
+                        files.selection_anchor = Some(paths[0].clone());
+                        files.selected = paths;
+                    }
+                }
+            }
+            return Some(Task::none());
         }
         if modifiers.control() || modifiers.alt() || modifiers.logo() {
             return None;
@@ -561,12 +583,16 @@ impl Oryxis {
                 }
                 // Files: a click selects a row AND deliberately drops the
                 // ring (`SidebarFilesSelectRow`), so a ring-less Del acts
-                // on what the mouse selected, the select-then-Del pair
-                // the SFTP pane offers.
-                let (path, is_dir) = self.sidebar_files_selected_entry(tab)?;
-                Some(self.update(Message::SidebarFiles(
-                    SidebarFilesMessage::SidebarFilesDelete(path, is_dir),
-                )))
+                // on what the mouse selected: the whole multi-selection,
+                // the select-then-Del pair the SFTP pane offers.
+                let selected = self.sidebar_files_selected_entries(tab)?;
+                let msg = if selected.len() == 1 {
+                    let (path, is_dir) = selected.into_iter().next().expect("len checked");
+                    SidebarFilesMessage::SidebarFilesDelete(path, is_dir)
+                } else {
+                    SidebarFilesMessage::SidebarFilesDeleteSelection(selected)
+                };
+                Some(self.update(Message::SidebarFiles(msg)))
             }
             Named::Escape => {
                 // Esc is the "give me the terminal back" key: drop the

--- a/crates/oryxis-app/src/dispatch_sidebar_files/entries.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/entries.rs
@@ -141,6 +141,68 @@ impl Oryxis {
                     Message::SidebarFiles(SidebarFilesMessage::SidebarFilesDeleteConfirmed(path, is_dir)),
                 );
             }
+            SidebarFilesMessage::SidebarFilesDeleteSelection(targets) => {
+                // Bulk delete from a multi-selection: same shared confirm
+                // dialog, with the SFTP modal's count-aware copy (folder /
+                // file breakdown) instead of a single name.
+                self.overlay = None;
+                if targets.is_empty() {
+                    return Task::none();
+                }
+                let (title, body) = if targets.len() == 1 {
+                    let (path, is_dir) = &targets[0];
+                    let name = files_basename(path);
+                    let detail = if *is_dir {
+                        format!(
+                            "\"{}\", {}",
+                            name,
+                            crate::i18n::t("folder_and_contents")
+                        )
+                    } else {
+                        format!("\"{name}\"")
+                    };
+                    (
+                        crate::i18n::t("delete_item_question").to_string(),
+                        detail,
+                    )
+                } else {
+                    let folder_count = targets.iter().filter(|(_, d)| *d).count();
+                    let file_count = targets.len() - folder_count;
+                    let detail = match (folder_count, file_count) {
+                        (0, n) => format!("{} {}", n, crate::i18n::t("files_lower")),
+                        (n, 0) => {
+                            format!("{} {}", n, crate::i18n::t("folders_recursive_lower"))
+                        }
+                        (f, fi) => format!(
+                            "{} {} {} {} {}",
+                            f,
+                            crate::i18n::t("folders_recursive_lower"),
+                            crate::i18n::t("and"),
+                            fi,
+                            crate::i18n::t("files_lower"),
+                        ),
+                    };
+                    (
+                        crate::i18n::t("delete_n_items_question")
+                            .replacen("{n}", &targets.len().to_string(), 1),
+                        detail,
+                    )
+                };
+                self.error_dialog = Some(crate::state::ErrorDialog {
+                    title,
+                    body,
+                    link: None,
+                    action: Some(crate::state::ErrorDialogAction {
+                        label: crate::i18n::t("delete").to_string(),
+                        message: Box::new(Message::SidebarFiles(
+                            SidebarFilesMessage::SidebarFilesDeleteConfirmedSelection(
+                                targets,
+                            ),
+                        )),
+                        danger: true,
+                    }),
+                });
+            }
             SidebarFilesMessage::SidebarFilesDeleteConfirmed(path, is_dir) => {
                 let Some(pane) = self.active_pane_mut() else {
                     return Task::none();
@@ -160,6 +222,20 @@ impl Oryxis {
                         client.remove_file(&path).await
                     }
                 });
+            }
+            SidebarFilesMessage::SidebarFilesDeleteConfirmedSelection(targets) => {
+                let Some(pane) = self.active_pane_mut() else {
+                    return Task::none();
+                };
+                let Some(client) = pane.files.client.clone() else {
+                    return Task::none();
+                };
+                let list_path = pane.files.path.clone();
+                let pane_id = pane.id;
+                pane.files.loading = true;
+                pane.files.error = None;
+                let seq = pane.files.next_req();
+                return bulk_delete_then_list(client, list_path, pane_id, seq, targets);
             }
             // The parent routed us here, so anything else is a
             // grouping mistake, not a runtime case.

--- a/crates/oryxis-app/src/dispatch_sidebar_files/entries.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/entries.rs
@@ -149,45 +149,12 @@ impl Oryxis {
                 if targets.is_empty() {
                     return Task::none();
                 }
-                let (title, body) = if targets.len() == 1 {
-                    let (path, is_dir) = &targets[0];
-                    let name = files_basename(path);
-                    let detail = if *is_dir {
-                        format!(
-                            "\"{}\", {}",
-                            name,
-                            crate::i18n::t("folder_and_contents")
-                        )
-                    } else {
-                        format!("\"{name}\"")
-                    };
-                    (
-                        crate::i18n::t("delete_item_question").to_string(),
-                        detail,
-                    )
-                } else {
-                    let folder_count = targets.iter().filter(|(_, d)| *d).count();
-                    let file_count = targets.len() - folder_count;
-                    let detail = match (folder_count, file_count) {
-                        (0, n) => format!("{} {}", n, crate::i18n::t("files_lower")),
-                        (n, 0) => {
-                            format!("{} {}", n, crate::i18n::t("folders_recursive_lower"))
-                        }
-                        (f, fi) => format!(
-                            "{} {} {} {} {}",
-                            f,
-                            crate::i18n::t("folders_recursive_lower"),
-                            crate::i18n::t("and"),
-                            fi,
-                            crate::i18n::t("files_lower"),
-                        ),
-                    };
-                    (
-                        crate::i18n::t("delete_n_items_question")
-                            .replacen("{n}", &targets.len().to_string(), 1),
-                        detail,
-                    )
-                };
+                let owned: Vec<(&str, bool)> = targets
+                    .iter()
+                    .map(|(p, d)| (p.as_str(), *d))
+                    .collect();
+                let (title, body) = crate::sftp_helpers::delete_confirm_copy(&owned);
+                drop(owned);
                 self.error_dialog = Some(crate::state::ErrorDialog {
                     title,
                     body,

--- a/crates/oryxis-app/src/dispatch_sidebar_files/listing.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/listing.rs
@@ -152,16 +152,20 @@ mod tests {
             permissions: None,
             uid: None,
             gid: None,
+            owner: None,
+            group: None,
         }
     }
 
     #[test]
     fn prune_drops_deleted_rows_and_their_anchor() {
-        let mut files = crate::state::PaneFiles::default();
-        files.path = "/srv".to_string();
-        files.entries = vec![entry("a.conf", false), entry("b.conf", false)];
-        files.selected = vec!["/srv/a.conf".to_string(), "/srv/gone".to_string()];
-        files.selection_anchor = Some("/srv/gone".to_string());
+        let mut files = crate::state::PaneFiles {
+            path: "/srv".to_string(),
+            entries: vec![entry("a.conf", false), entry("b.conf", false)],
+            selected: vec!["/srv/a.conf".to_string(), "/srv/gone".to_string()],
+            selection_anchor: Some("/srv/gone".to_string()),
+            ..Default::default()
+        };
         prune_selection(&mut files, "/srv");
         assert_eq!(files.selected, vec!["/srv/a.conf".to_string()]);
         // The anchor's row no longer exists, so a later shift-click
@@ -171,11 +175,13 @@ mod tests {
 
     #[test]
     fn prune_keeps_surviving_anchor() {
-        let mut files = crate::state::PaneFiles::default();
-        files.path = "/srv".to_string();
-        files.entries = vec![entry("a.conf", false), entry("b.conf", false)];
-        files.selected = vec!["/srv/a.conf".to_string(), "/srv/b.conf".to_string()];
-        files.selection_anchor = Some("/srv/a.conf".to_string());
+        let mut files = crate::state::PaneFiles {
+            path: "/srv".to_string(),
+            entries: vec![entry("a.conf", false), entry("b.conf", false)],
+            selected: vec!["/srv/a.conf".to_string(), "/srv/b.conf".to_string()],
+            selection_anchor: Some("/srv/a.conf".to_string()),
+            ..Default::default()
+        };
         prune_selection(&mut files, "/srv");
         assert_eq!(
             files.selected,
@@ -186,10 +192,12 @@ mod tests {
 
     #[test]
     fn prune_clears_an_empty_selection() {
-        let mut files = crate::state::PaneFiles::default();
-        files.path = "/srv".to_string();
-        files.entries = vec![entry("a.conf", false)];
-        files.selection_anchor = Some("/srv/a.conf".to_string());
+        let mut files = crate::state::PaneFiles {
+            path: "/srv".to_string(),
+            entries: vec![entry("a.conf", false)],
+            selection_anchor: Some("/srv/a.conf".to_string()),
+            ..Default::default()
+        };
         prune_selection(&mut files, "/srv");
         assert!(files.selected.is_empty());
         assert_eq!(files.selection_anchor, None);

--- a/crates/oryxis-app/src/dispatch_sidebar_files/listing.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/listing.rs
@@ -111,16 +111,87 @@ impl Oryxis {
 }
 
 /// A listing replaced the rows: the double-click stamp is stale by
-/// definition, and the selection survives only when its entry is
-/// still present (a same-directory refresh, an op_then_list
-/// completion); a listing of any other directory drops it.
+/// definition, and the selection survives only while every selected
+/// entry is still present (a same-directory refresh, an op_then_list
+/// completion); a listing of any other directory drops it. The
+/// shift-click anchor follows the same rule, so a later shift-click
+/// never extends from a row that is no longer there.
 fn prune_selection(files: &mut crate::state::PaneFiles, path: &str) {
     files.last_click = None;
-    let keep = files
+    if files.selected.is_empty() {
+        files.selection_anchor = None;
+        return;
+    }
+    files
         .selected
-        .as_deref()
-        .is_some_and(|s| files.entries.iter().any(|e| files_join(path, &e.name) == s));
-    if !keep {
-        files.selected = None;
+        .retain(|s| files.entries.iter().any(|e| files_join(path, &e.name) == *s));
+    if files.selected.is_empty() {
+        files.selection_anchor = None;
+    } else {
+        files.selection_anchor = files.selection_anchor.as_ref().and_then(|a| {
+            files
+                .entries
+                .iter()
+                .any(|e| files_join(path, &e.name) == *a)
+                .then(|| a.clone())
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, is_dir: bool) -> oryxis_ssh::SftpEntry {
+        oryxis_ssh::SftpEntry {
+            name: name.to_string(),
+            is_dir,
+            is_symlink: false,
+            size: 0,
+            mtime: None,
+            permissions: None,
+            uid: None,
+            gid: None,
+        }
+    }
+
+    #[test]
+    fn prune_drops_deleted_rows_and_their_anchor() {
+        let mut files = crate::state::PaneFiles::default();
+        files.path = "/srv".to_string();
+        files.entries = vec![entry("a.conf", false), entry("b.conf", false)];
+        files.selected = vec!["/srv/a.conf".to_string(), "/srv/gone".to_string()];
+        files.selection_anchor = Some("/srv/gone".to_string());
+        prune_selection(&mut files, "/srv");
+        assert_eq!(files.selected, vec!["/srv/a.conf".to_string()]);
+        // The anchor's row no longer exists, so a later shift-click
+        // must not extend from it.
+        assert_eq!(files.selection_anchor, None);
+    }
+
+    #[test]
+    fn prune_keeps_surviving_anchor() {
+        let mut files = crate::state::PaneFiles::default();
+        files.path = "/srv".to_string();
+        files.entries = vec![entry("a.conf", false), entry("b.conf", false)];
+        files.selected = vec!["/srv/a.conf".to_string(), "/srv/b.conf".to_string()];
+        files.selection_anchor = Some("/srv/a.conf".to_string());
+        prune_selection(&mut files, "/srv");
+        assert_eq!(
+            files.selected,
+            vec!["/srv/a.conf".to_string(), "/srv/b.conf".to_string()]
+        );
+        assert_eq!(files.selection_anchor.as_deref(), Some("/srv/a.conf"));
+    }
+
+    #[test]
+    fn prune_clears_an_empty_selection() {
+        let mut files = crate::state::PaneFiles::default();
+        files.path = "/srv".to_string();
+        files.entries = vec![entry("a.conf", false)];
+        files.selection_anchor = Some("/srv/a.conf".to_string());
+        prune_selection(&mut files, "/srv");
+        assert!(files.selected.is_empty());
+        assert_eq!(files.selection_anchor, None);
     }
 }

--- a/crates/oryxis-app/src/dispatch_sidebar_files/menus.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/menus.rs
@@ -13,12 +13,43 @@ impl Oryxis {
     ) -> Task<Message> {
         match message {
             SidebarFilesMessage::ShowSidebarFilesRowMenu(path, is_dir) => {
+                // Right-click semantics (Explorer / Finder, and the SFTP
+                // pane's rule): right-clicking a row that is part of the
+                // current selection KEEPS the selection, so the menu
+                // actions apply to all of it; right-clicking an outside
+                // row re-selects just that row so the menu can never
+                // silently target a different set than the rows shown
+                // highlighted.
+                if let Some(pane) = self.active_pane_mut()
+                    && !pane.files.selected.iter().any(|p| p == &path)
+                {
+                    pane.files.selected = vec![path.clone()];
+                    pane.files.selection_anchor = Some(path.clone());
+                }
                 let anchor = self.keynav_take_menu_anchor();
                 self.overlay = Some(crate::state::OverlayState {
                     content: crate::state::OverlayContent::SidebarFilesRow { path, is_dir },
                     x: anchor.0,
                     y: anchor.1,
                 });
+            }
+            SidebarFilesMessage::SidebarFilesCopySelectionPaths => {
+                // Bulk variant of Copy path: every selected path in the
+                // browser, one per line (the SFTP pane's rule). The
+                // menu is dismissed; the selection stays, copying is
+                // not an action "on" the rows the way delete is.
+                self.overlay = None;
+                let Some(pane) = self.active_pane_mut() else {
+                    return Task::none();
+                };
+                let paths: Vec<String> = super::selected_items(&pane.files)
+                    .into_iter()
+                    .map(|(p, _)| p)
+                    .collect();
+                if paths.is_empty() {
+                    return Task::none();
+                }
+                return self.update(Message::CopyToClipboard(paths.join("\n")));
             }
             SidebarFilesMessage::ShowSidebarFilesBackgroundMenu => {
                 // Directory-level menu for the current folder; only once

--- a/crates/oryxis-app/src/dispatch_sidebar_files/mod.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/mod.rs
@@ -186,13 +186,19 @@ pub(crate) fn selected_items(files: &crate::state::PaneFiles) -> Vec<(String, bo
 /// descriptors the drag data object doesn't build yet, matching the
 /// SFTP pane's rule), capped like it too; `None` when there is
 /// nothing to carry. Returns `(payload, ghost label)`.
-fn sidebar_drag_out_payload(
+///
+/// Deliberately does NOT ask `drag_out::supported()`: that is a
+/// platform answer (`cfg!(windows)`), not a fact about the selection,
+/// and asking it here made the whole function unreachable off Windows
+/// including from a unit test, which is where the selection rules are
+/// worth pinning. The caller gates on it.
+pub(crate) fn sidebar_drag_out_payload(
     files: &crate::state::PaneFiles,
     path: &str,
     is_dir: bool,
 ) -> Option<(crate::drag_out::DragOutPayload, String)> {
     const MAX_DRAG_OUT_FILES: usize = 64;
-    if is_dir || !crate::drag_out::supported() {
+    if is_dir {
         return None;
     }
     let mut items: Vec<String> = if files.selected.iter().any(|p| p == path) {
@@ -773,15 +779,17 @@ mod tests {
 
     #[test]
     fn visible_paths_follow_the_listing_and_hidden_filter() {
-        let mut files = crate::state::PaneFiles::default();
-        files.path = "/srv".to_string();
-        files.entries = vec![
-            entry("a.conf", 10),
-            oryxis_ssh::SftpEntry {
-                name: ".hidden".to_string(),
-                ..entry(".hidden", 0)
-            },
-        ];
+        let mut files = crate::state::PaneFiles {
+            path: "/srv".to_string(),
+            entries: vec![
+                entry("a.conf", 10),
+                oryxis_ssh::SftpEntry {
+                    name: ".hidden".to_string(),
+                    ..entry(".hidden", 0)
+                },
+            ],
+            ..Default::default()
+        };
         // Hidden rows are invisible to a shift-click range, exactly as
         // they are to the mouse.
         assert_eq!(visible_entry_paths(&files), vec!["/srv/a.conf"]);
@@ -794,10 +802,12 @@ mod tests {
 
     #[test]
     fn selected_items_returns_listing_rows_not_stale_paths() {
-        let mut files = crate::state::PaneFiles::default();
-        files.path = "/srv".to_string();
-        files.entries = vec![entry("a.conf", 10), dir_entry("docs")];
-        files.selected = vec!["/srv/a.conf".to_string(), "/srv/gone".to_string()];
+        let files = crate::state::PaneFiles {
+            path: "/srv".to_string(),
+            entries: vec![entry("a.conf", 10), dir_entry("docs")],
+            selected: vec!["/srv/a.conf".to_string(), "/srv/gone".to_string()],
+            ..Default::default()
+        };
         // The stale path (already deleted from the listing) does not
         // produce a target, and directories report `is_dir`.
         assert_eq!(selected_items(&files), vec![("/srv/a.conf".to_string(), false)]);
@@ -805,22 +815,24 @@ mod tests {
 
     #[test]
     fn drag_out_payload_carries_the_selection() {
-        let mut files = crate::state::PaneFiles::default();
-        files.path = "/srv".to_string();
-        files.entries = vec![
-            entry("a.conf", 10),
-            entry("b.conf", 20),
-            entry("c.conf", 30),
-            dir_entry("docs"),
-        ];
-        files.selected = vec![
-            "/srv/a.conf".to_string(),
-            "/srv/b.conf".to_string(),
-            "/srv/docs".to_string(),
-        ];
-        files.client = Some(crate::local_files::FilesClient::Local(
-            crate::local_files::LocalFs,
-        ));
+        let files = crate::state::PaneFiles {
+            path: "/srv".to_string(),
+            entries: vec![
+                entry("a.conf", 10),
+                entry("b.conf", 20),
+                entry("c.conf", 30),
+                dir_entry("docs"),
+            ],
+            selected: vec![
+                "/srv/a.conf".to_string(),
+                "/srv/b.conf".to_string(),
+                "/srv/docs".to_string(),
+            ],
+            client: Some(crate::local_files::FilesClient::Local(
+                crate::local_files::LocalFs,
+            )),
+            ..Default::default()
+        };
         // Pressing a selected FILE row drags every file of the
         // selection; the directory stays behind (no recursive payload).
         let (payload, label) = sidebar_drag_out_payload(&files, "/srv/b.conf", false)

--- a/crates/oryxis-app/src/dispatch_sidebar_files/mod.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/mod.rs
@@ -153,6 +153,100 @@ fn expand_cwd(cwd: &str, home: Option<&str>) -> Option<String> {
     cwd.strip_prefix("~/").map(|rest| format!("{home}/{rest}"))
 }
 
+/// Ordered full paths of the rows the browser is actually showing
+/// (hidden-filtered, no ".." row): the list a shift-click range
+/// select indexes into, mirroring the SFTP pane's
+/// `visible_entry_paths_in_pane`.
+pub(crate) fn visible_entry_paths(files: &crate::state::PaneFiles) -> Vec<String> {
+    files
+        .entries
+        .iter()
+        .filter(|e| files.show_hidden || !e.name.starts_with('.'))
+        .map(|e| files_join(&files.path, &e.name))
+        .collect()
+}
+
+/// `(full path, is_dir)` for every selected row still present in the
+/// listing, in listing order. Feeds the bulk delete confirm, the
+/// selection drag-out and the ring-less Del; a selection only ever
+/// contains visible rows (they are the only clickable ones), so no
+/// hidden filter is needed here.
+pub(crate) fn selected_items(files: &crate::state::PaneFiles) -> Vec<(String, bool)> {
+    files
+        .entries
+        .iter()
+        .filter(|e| files.selected.iter().any(|s| files_join(&files.path, &e.name) == *s))
+        .map(|e| (files_join(&files.path, &e.name), e.is_dir))
+        .collect()
+}
+
+/// Build the drag-out payload (issue #167) for a pressed sidebar row:
+/// the whole current selection when the row is part of it, else just
+/// that row. Only FILES travel (a directory needs recursive
+/// descriptors the drag data object doesn't build yet, matching the
+/// SFTP pane's rule), capped like it too; `None` when there is
+/// nothing to carry. Returns `(payload, ghost label)`.
+fn sidebar_drag_out_payload(
+    files: &crate::state::PaneFiles,
+    path: &str,
+    is_dir: bool,
+) -> Option<(crate::drag_out::DragOutPayload, String)> {
+    const MAX_DRAG_OUT_FILES: usize = 64;
+    if is_dir || !crate::drag_out::supported() {
+        return None;
+    }
+    let mut items: Vec<String> = if files.selected.iter().any(|p| p == path) {
+        files.selected.clone()
+    } else {
+        vec![path.to_string()]
+    };
+    items.retain(|p| {
+        files
+            .entries
+            .iter()
+            .any(|e| !e.is_dir && files_join(&files.path, &e.name) == *p)
+    });
+    if items.is_empty() || items.len() > MAX_DRAG_OUT_FILES {
+        return None;
+    }
+    let label = if items.len() > 1 {
+        format!(
+            "{} {}",
+            items.len(),
+            crate::i18n::t("sftp_log_items"),
+        )
+    } else {
+        files_basename(&items[0])
+    };
+    let payload = match files.client.as_ref()? {
+        crate::local_files::FilesClient::Local(_) => {
+            crate::drag_out::DragOutPayload::Local(
+                items.into_iter().map(std::path::PathBuf::from).collect(),
+            )
+        }
+        crate::local_files::FilesClient::Sftp(client) => {
+            let files = items
+                .into_iter()
+                .map(|p| {
+                    let name = files_basename(&p);
+                    let size = files
+                        .entries
+                        .iter()
+                        .find(|e| e.name == name)
+                        .map(|e| e.size)
+                        .unwrap_or(0);
+                    crate::drag_out::RemoteDragFile { path: p, name, size }
+                })
+                .collect();
+            crate::drag_out::DragOutPayload::Remote {
+                client: client.clone(),
+                files,
+            }
+        }
+    };
+    Some((payload, label))
+}
+
 /// Cap per host, matching the per-pane dropdown's own cap: the list is
 /// there to be scanned, not archived.
 const FILES_RECENT_CAP: usize = 20;
@@ -252,6 +346,7 @@ impl Oryxis {
                 SidebarFilesMessage::ShowSidebarFilesRowMenu(..)
                 | SidebarFilesMessage::ShowSidebarFilesBackgroundMenu
                 | SidebarFilesMessage::SidebarFilesShowProperties(..)
+                | SidebarFilesMessage::SidebarFilesCopySelectionPaths
             ) => self.handle_sidebar_files_menus(m),
             m @ (
                 SidebarFilesMessage::SidebarFilesStartRename(..)
@@ -262,6 +357,8 @@ impl Oryxis {
                 | SidebarFilesMessage::SidebarFilesNewEntryCommit
                 | SidebarFilesMessage::SidebarFilesDelete(..)
                 | SidebarFilesMessage::SidebarFilesDeleteConfirmed(..)
+                | SidebarFilesMessage::SidebarFilesDeleteSelection(..)
+                | SidebarFilesMessage::SidebarFilesDeleteConfirmedSelection(..)
             ) => self.handle_sidebar_files_entries(m),
             m @ (
                 SidebarFilesMessage::SidebarFilesDownload(..)
@@ -293,6 +390,19 @@ impl Oryxis {
                 p.files.client.as_ref().is_some_and(|c| c.is_local())
                     || (p.session.is_none()
                         && matches!(p.origin, crate::state::PaneOrigin::Local(_)))
+            })
+    }
+
+    /// Whether the sidebar Files selection is a multi-selection that
+    /// contains `path` (the row the context menu opened on). The row
+    /// menu collapses to the bulk actions (Copy N paths / Delete N
+    /// items) when so, mirroring the SFTP pane.
+    pub(crate) fn sidebar_files_multi(&self, path: &str) -> bool {
+        self.active_tab
+            .and_then(|i| self.tabs.get(i))
+            .map(|t| t.active())
+            .is_some_and(|p| {
+                p.files.selected.len() > 1 && p.files.selected.iter().any(|s| s == path)
             })
     }
 
@@ -483,6 +593,39 @@ fn op_then_list(
     )
 }
 
+/// Delete N entries then re-list once, all on the sidebar browser's
+/// channel: the bulk sibling of `op_then_list` (a multi-selection
+/// delete must not re-list once per row). A failing delete stops the
+/// walk with the error, like the SFTP pane's bulk walk.
+fn bulk_delete_then_list(
+    client: crate::local_files::FilesClient,
+    list_path: String,
+    pane_id: Uuid,
+    seq: u64,
+    targets: Vec<(String, bool)>,
+) -> Task<Message> {
+    Task::perform(
+        async move {
+            for (path, is_dir) in targets {
+                let result = if is_dir {
+                    client.remove_dir_recursive(&path).await
+                } else {
+                    client.remove_file(&path).await
+                };
+                if let Err(e) = result {
+                    return Err(e.to_string());
+                }
+            }
+            let entries = client.list_dir(&list_path).await.map_err(|e| e.to_string())?;
+            Ok::<_, String>((list_path, entries))
+        },
+        move |result| match result {
+            Ok((path, entries)) => Message::SidebarFiles(SidebarFilesMessage::SidebarFilesListed(pane_id, seq, path, entries)),
+            Err(e) => Message::SidebarFiles(SidebarFilesMessage::SidebarFilesError(pane_id, seq, e)),
+        },
+    )
+}
+
 /// One directory listing on the sidebar browser's channel. `seq` is the
 /// request stamp compared on completion (latest request wins).
 /// `pub(crate)`: the OS-drop upload refreshes the visible listing on
@@ -617,5 +760,89 @@ mod tests {
         // Remote POSIX paths never trip the detection.
         assert!(!is_windows_path("/var/c:d"));
         assert!(is_windows_path(r"C:\Users"));
+    }
+
+    fn dir_entry(name: &str) -> oryxis_ssh::SftpEntry {
+        oryxis_ssh::SftpEntry {
+            is_dir: true,
+            ..entry(name, 0)
+        }
+    }
+
+    #[test]
+    fn visible_paths_follow_the_listing_and_hidden_filter() {
+        let mut files = crate::state::PaneFiles::default();
+        files.path = "/srv".to_string();
+        files.entries = vec![
+            entry("a.conf", 10),
+            oryxis_ssh::SftpEntry {
+                name: ".hidden".to_string(),
+                ..entry(".hidden", 0)
+            },
+        ];
+        // Hidden rows are invisible to a shift-click range, exactly as
+        // they are to the mouse.
+        assert_eq!(visible_entry_paths(&files), vec!["/srv/a.conf"]);
+        files.show_hidden = true;
+        assert_eq!(
+            visible_entry_paths(&files),
+            vec!["/srv/a.conf", "/srv/.hidden"]
+        );
+    }
+
+    #[test]
+    fn selected_items_returns_listing_rows_not_stale_paths() {
+        let mut files = crate::state::PaneFiles::default();
+        files.path = "/srv".to_string();
+        files.entries = vec![entry("a.conf", 10), dir_entry("docs")];
+        files.selected = vec!["/srv/a.conf".to_string(), "/srv/gone".to_string()];
+        // The stale path (already deleted from the listing) does not
+        // produce a target, and directories report `is_dir`.
+        assert_eq!(selected_items(&files), vec![("/srv/a.conf".to_string(), false)]);
+    }
+
+    #[test]
+    fn drag_out_payload_carries_the_selection() {
+        let mut files = crate::state::PaneFiles::default();
+        files.path = "/srv".to_string();
+        files.entries = vec![
+            entry("a.conf", 10),
+            entry("b.conf", 20),
+            entry("c.conf", 30),
+            dir_entry("docs"),
+        ];
+        files.selected = vec![
+            "/srv/a.conf".to_string(),
+            "/srv/b.conf".to_string(),
+            "/srv/docs".to_string(),
+        ];
+        files.client = Some(crate::local_files::FilesClient::Local(
+            crate::local_files::LocalFs,
+        ));
+        // Pressing a selected FILE row drags every file of the
+        // selection; the directory stays behind (no recursive payload).
+        let (payload, label) = sidebar_drag_out_payload(&files, "/srv/b.conf", false)
+            .expect("a file row in the selection arms a drag-out");
+        assert!(label.contains('2'), "label should show the count: {label}");
+        match payload {
+            crate::drag_out::DragOutPayload::Local(paths) => {
+                assert_eq!(paths.len(), 2);
+                assert!(paths.contains(&std::path::PathBuf::from("/srv/a.conf")));
+                assert!(paths.contains(&std::path::PathBuf::from("/srv/b.conf")));
+            }
+            other => panic!("expected a Local payload, got {other:?}"),
+        }
+        // Pressing a directory row never arms (the old rule), and an
+        // outside-of-the-selection row drags just itself.
+        assert!(sidebar_drag_out_payload(&files, "/srv/docs", true).is_none());
+        let (payload, label) = sidebar_drag_out_payload(&files, "/srv/c.conf", false)
+            .expect("an unselected file row drags itself");
+        assert_eq!(label, "c.conf");
+        match payload {
+            crate::drag_out::DragOutPayload::Local(paths) => {
+                assert_eq!(paths, vec![std::path::PathBuf::from("/srv/c.conf")]);
+            }
+            other => panic!("expected a Local payload, got {other:?}"),
+        }
     }
 }

--- a/crates/oryxis-app/src/dispatch_sidebar_files/mod.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/mod.rs
@@ -362,6 +362,8 @@ impl Oryxis {
             ) => self.handle_sidebar_files_entries(m),
             m @ (
                 SidebarFilesMessage::SidebarFilesDownload(..)
+                | SidebarFilesMessage::SidebarFilesDownloadSelection
+                | SidebarFilesMessage::SidebarFilesDownloadSelectionPicked(..)
                 | SidebarFilesMessage::SidebarFilesDownloadPicked(..)
                 | SidebarFilesMessage::SidebarFilesUploadInto(..)
                 | SidebarFilesMessage::SidebarFilesUploadPicked(..)

--- a/crates/oryxis-app/src/dispatch_sidebar_files/navigate.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/navigate.rs
@@ -26,12 +26,19 @@ impl Oryxis {
             }
             SidebarFilesMessage::SidebarFilesSelectRow(path, is_dir) => {
                 // Single-click selects the row (highlight); double-click
-                // on a directory enters it, matching the SFTP pane's rule.
+                // on a directory enters it. Ctrl/Cmd-click toggles a row
+                // in/out of the selection and Shift-click extends a range
+                // from the anchor, matching the dual-pane SFTP surface.
                 // The click hands the cursor to the mouse: a keynav ring
                 // engaged elsewhere is dropped so Enter can't act on a row
                 // the user just clicked away from (the selection anchors
                 // the next arrow entry right here instead).
                 self.keynav.sidebar_selected = None;
+                // Modifiers are read off `self` first: the pane borrow
+                // below outlives the selection edit.
+                let ctrl = self.modifiers.control() || self.modifiers.command();
+                let shift = self.modifiers.shift();
+                let now = std::time::Instant::now();
                 let Some(pane) = self.active_pane_mut() else {
                     return Task::none();
                 };
@@ -40,63 +47,90 @@ impl Oryxis {
                 // back to the label + actions.
                 pane.files.path_editing = None;
                 pane.files.path_history_open = false;
-                let now = std::time::Instant::now();
-                let is_double = pane.files.last_click.as_ref().is_some_and(
-                    |(t, p)| p == &path && now.duration_since(*t) < DOUBLE_CLICK_WINDOW,
-                );
-                pane.files.last_click = Some((now, path.clone()));
-                pane.files.selected = Some(path.clone());
+                // Only a PLAIN click can be a double-click: a ctrl/shift
+                // press is selection-building, never an enter (the SFTP
+                // pane's rule).
+                let is_double = !ctrl
+                    && !shift
+                    && pane.files.last_click.as_ref().is_some_and(
+                        |(t, p)| p == &path && now.duration_since(*t) < DOUBLE_CLICK_WINDOW,
+                    );
                 if is_double && is_dir {
                     pane.files.last_click = None;
-                    pane.files.selected = None;
+                    pane.files.selected.clear();
+                    pane.files.selection_anchor = None;
                     return self.update(Message::SidebarFiles(
                         SidebarFilesMessage::SidebarFilesNavigate(path),
                     ));
+                }
+                // The double-click detector only feeds on plain clicks
+                // too, so a ctrl/shift press can't leave a stale stamp
+                // that turns the next plain click into an enter.
+                pane.files.last_click = if ctrl || shift {
+                    None
+                } else {
+                    Some((now, path.clone()))
+                };
+                if shift {
+                    // Range select within the visible listing. If the
+                    // anchor row is gone (refresh / delete pruned it) or
+                    // the target can't be indexed, fall through to a
+                    // single-select instead of silently growing the
+                    // range from nowhere.
+                    let range = pane.files.selection_anchor.as_ref().and_then(|anchor| {
+                        let entries = super::visible_entry_paths(&pane.files);
+                        let a = entries.iter().position(|p| p == anchor);
+                        let t = entries.iter().position(|p| p == &path);
+                        match (a, t) {
+                            (Some(ai), Some(ti)) => {
+                                let (lo, hi) = if ai <= ti { (ai, ti) } else { (ti, ai) };
+                                Some(entries[lo..=hi].to_vec())
+                            }
+                            _ => None,
+                        }
+                    });
+                    if let Some(range) = range {
+                        pane.files.selected = range;
+                        // No early return: the shared drag-out arm
+                        // below builds its payload from the selection as
+                        // it stands now, so the fresh range drags as one
+                        // (the fall-through is what makes this branch
+                        // two lines instead of ten).
+                    } else {
+                        pane.files.selected = vec![path.clone()];
+                        pane.files.selection_anchor = Some(path.clone());
+                    }
+                } else if ctrl {
+                    // Ctrl-click toggle. Anchor follows the click so a
+                    // subsequent shift-click extends from here.
+                    if let Some(pos) = pane.files.selected.iter().position(|p| p == &path) {
+                        pane.files.selected.remove(pos);
+                    } else {
+                        pane.files.selected.push(path.clone());
+                    }
+                    pane.files.selection_anchor = Some(path.clone());
+                } else {
+                    pane.files.selected = vec![path.clone()];
+                    pane.files.selection_anchor = Some(path.clone());
                 }
                 // Arm a drag-out (issue #167) on FILE rows where a
                 // backend can serve it: crossing the movement threshold
                 // while the button is still down raises the ghost, and
                 // leaving the window turns the press into an OS drag
                 // (see `advance_drag_out`); a plain click stays exactly
-                // the select it always was. The payload is built NOW,
-                // while the pane is in hand; the press anchor was
-                // synced at the top of `update`.
-                let mut ghost_label = String::new();
-                let arm = (!is_dir && crate::drag_out::supported())
-                    .then(|| {
-                        let name = files_basename(&path);
-                        ghost_label = name.clone();
-                        let size = pane
-                            .files
-                            .entries
-                            .iter()
-                            .find(|e| e.name == name)
-                            .map(|e| e.size)
-                            .unwrap_or(0);
-                        match pane.files.client.as_ref()? {
-                            crate::local_files::FilesClient::Local(_) => {
-                                Some(crate::drag_out::DragOutPayload::Local(vec![
-                                    std::path::PathBuf::from(&path),
-                                ]))
-                            }
-                            crate::local_files::FilesClient::Sftp(client) => {
-                                Some(crate::drag_out::DragOutPayload::Remote {
-                                    client: client.clone(),
-                                    files: vec![crate::drag_out::RemoteDragFile {
-                                        path: path.clone(),
-                                        name,
-                                        size,
-                                    }],
-                                })
-                            }
-                        }
-                    })
-                    .flatten();
-                self.drag_out_arm = arm.map(|payload| crate::drag_out::DragOutArm {
-                    press: self.mouse_position,
-                    label: ghost_label,
-                    stage: crate::drag_out::DragOutStage::Armed(payload),
-                });
+                // the select it always was. A press on a row that is
+                // part of a multi-selection carries the whole
+                // selection; a press on an outside row carries just
+                // that row. The payload is built NOW, while the pane
+                // is in hand; the press anchor was synced at the top of
+                // `update`.
+                let arm = super::sidebar_drag_out_payload(&pane.files, &path, is_dir)
+                    .map(|(payload, label)| crate::drag_out::DragOutArm {
+                        press: self.mouse_position,
+                        label,
+                        stage: crate::drag_out::DragOutStage::Armed(payload),
+                    });
+                self.drag_out_arm = arm;
             }
             SidebarFilesMessage::SidebarFilesToggleFollow => {
                 if let Some(pane) = self.active_pane_mut() {
@@ -180,7 +214,8 @@ impl Oryxis {
                 pane.files.entries.clear();
                 pane.files.loading = true;
                 pane.files.error = None;
-                pane.files.selected = None;
+                pane.files.selected.clear();
+                pane.files.selection_anchor = None;
                 pane.files.last_click = None;
                 // Rapid clicks race their listings; the stamp makes the
                 // LATEST navigation win regardless of completion order.

--- a/crates/oryxis-app/src/dispatch_sidebar_files/navigate.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/navigate.rs
@@ -39,6 +39,10 @@ impl Oryxis {
                 let ctrl = self.modifiers.control() || self.modifiers.command();
                 let shift = self.modifiers.shift();
                 let now = std::time::Instant::now();
+                // Read off `self` with the modifiers, for the same
+                // reason: the arm below is built while the pane borrow
+                // is live.
+                let press_pos = self.mouse_position;
                 let Some(pane) = self.active_pane_mut() else {
                     return Task::none();
                 };
@@ -47,6 +51,34 @@ impl Oryxis {
                 // back to the label + actions.
                 pane.files.path_editing = None;
                 pane.files.path_history_open = false;
+                // Arm a drag-out (issue #167) on FILE rows where a
+                // backend can serve it: crossing the movement threshold
+                // while the button is still down raises the ghost, and
+                // leaving the window turns the press into an OS drag
+                // (see `advance_drag_out`); a plain click stays exactly
+                // the select it always was.
+                //
+                // BEFORE the selection edit below, which is the whole
+                // reason a multi-selection can be dragged at all: a
+                // plain press collapses `selected` to the pressed row,
+                // so a payload built after it would carry one file no
+                // matter how many were highlighted, and the gesture the
+                // selection exists for (pick several, drag one of them
+                // out) would silently drop the rest. `SftpSelectRow`
+                // arms in the same position and says so.
+                // Computed here, PUBLISHED at the end: `pane` still owns
+                // the borrow through the selection edit, and the value
+                // is what has to be captured early, not the assignment.
+                let arm = crate::drag_out::supported()
+                    .then(|| super::sidebar_drag_out_payload(&pane.files, &path, is_dir))
+                    .flatten()
+                    .map(
+                    |(payload, label)| crate::drag_out::DragOutArm {
+                        press: press_pos,
+                        label,
+                        stage: crate::drag_out::DragOutStage::Armed(payload),
+                    },
+                );
                 // Only a PLAIN click can be a double-click: a ctrl/shift
                 // press is selection-building, never an enter (the SFTP
                 // pane's rule).
@@ -91,11 +123,14 @@ impl Oryxis {
                     });
                     if let Some(range) = range {
                         pane.files.selected = range;
-                        // No early return: the shared drag-out arm
-                        // below builds its payload from the selection as
-                        // it stands now, so the fresh range drags as one
-                        // (the fall-through is what makes this branch
-                        // two lines instead of ten).
+                        // No early return: the shared publish at the
+                        // bottom still has to run. The payload it
+                        // publishes was taken BEFORE this range was
+                        // built, which is the same answer the SFTP pane
+                        // gives (it arms ahead of its own collapse):
+                        // what a press drags is what was selected when
+                        // the button went down, not what the same press
+                        // then selected.
                     } else {
                         pane.files.selected = vec![path.clone()];
                         pane.files.selection_anchor = Some(path.clone());
@@ -113,23 +148,6 @@ impl Oryxis {
                     pane.files.selected = vec![path.clone()];
                     pane.files.selection_anchor = Some(path.clone());
                 }
-                // Arm a drag-out (issue #167) on FILE rows where a
-                // backend can serve it: crossing the movement threshold
-                // while the button is still down raises the ghost, and
-                // leaving the window turns the press into an OS drag
-                // (see `advance_drag_out`); a plain click stays exactly
-                // the select it always was. A press on a row that is
-                // part of a multi-selection carries the whole
-                // selection; a press on an outside row carries just
-                // that row. The payload is built NOW, while the pane
-                // is in hand; the press anchor was synced at the top of
-                // `update`.
-                let arm = super::sidebar_drag_out_payload(&pane.files, &path, is_dir)
-                    .map(|(payload, label)| crate::drag_out::DragOutArm {
-                        press: self.mouse_position,
-                        label,
-                        stage: crate::drag_out::DragOutStage::Armed(payload),
-                    });
                 self.drag_out_arm = arm;
             }
             SidebarFilesMessage::SidebarFilesToggleFollow => {

--- a/crates/oryxis-app/src/dispatch_sidebar_files/path_bar.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/path_bar.rs
@@ -40,7 +40,8 @@ impl Oryxis {
                     files.rename = None;
                     files.new_entry = None;
                     files.path_history_open = false;
-                    files.selected = None;
+                    files.selected.clear();
+                    files.selection_anchor = None;
                     files.last_click = None;
                 }
             }

--- a/crates/oryxis-app/src/dispatch_sidebar_files/transfer.rs
+++ b/crates/oryxis-app/src/dispatch_sidebar_files/transfer.rs
@@ -62,6 +62,141 @@ impl Oryxis {
                     },
                 )
             }
+            SidebarFilesMessage::SidebarFilesDownloadSelection => {
+                // Bulk sibling of the single download: a directory picker
+                // instead of a save dialog, then every selected entry
+                // enqueues under it (directories walk recursively).
+                self.overlay = None;
+                let Some(pane) = self.active_pane_mut() else {
+                    return Task::none();
+                };
+                // A local browser has nothing to download (issue #145).
+                if pane.files.client.as_ref().and_then(|c| c.sftp()).is_none() {
+                    return Task::none();
+                }
+                // The selection as it stands in the listing; snapshotted
+                // here so a navigation while the dialog is open cannot
+                // shift what gets downloaded.
+                let targets = super::selected_items(&pane.files);
+                if targets.is_empty() {
+                    return Task::none();
+                }
+                let pane_id = pane.id;
+                let start = self
+                    .last_download_dir
+                    .clone()
+                    .unwrap_or_else(|| self.default_download_dir());
+                Task::perform(
+                    async move {
+                        rfd::AsyncFileDialog::new()
+                            .set_directory(&start)
+                            .pick_folder()
+                            .await
+                            .map(|f| f.path().to_path_buf())
+                    },
+                    move |dest| match dest {
+                        Some(dest) => Message::SidebarFiles(
+                            SidebarFilesMessage::SidebarFilesDownloadSelectionPicked(
+                                pane_id,
+                                dest.to_string_lossy().into_owned(),
+                                targets,
+                            ),
+                        ),
+                        None => Message::NoOp,
+                    },
+                )
+            }
+            SidebarFilesMessage::SidebarFilesDownloadSelectionPicked(pane_id, dir, targets) => {
+                // The dialog resolved later, so the pane is resolved by
+                // id like any completion: the user is free to switch tabs
+                // while it is open.
+                let Some(pane) = self.pane_by_id_any_tab(pane_id) else {
+                    return Task::none();
+                };
+                let Some(client) = pane.files.client.as_ref().and_then(|c| c.sftp().cloned())
+                else {
+                    return Task::none();
+                };
+                if targets.is_empty() {
+                    return Task::none();
+                }
+                // Seed the next dialog with the folder this one landed in
+                // (see `SidebarFilesDownload`).
+                self.last_download_dir = Some(std::path::PathBuf::from(&dir));
+                let concurrency = self.sftp_concurrency();
+                let label = if targets.len() == 1 {
+                    files_basename(&targets[0].0)
+                } else {
+                    format!(
+                        "{} {}",
+                        targets.len(),
+                        crate::i18n::t("sftp_log_items"),
+                    )
+                };
+                // Same queue machinery as the single download: directories
+                // push their root then walk recursively into the queue
+                // (the SFTP pane's batch rule), so a selected folder
+                // arrives with all of its contents and the progress bar
+                // has real byte totals.
+                let dir_path = std::path::PathBuf::from(&dir);
+                Task::perform(
+                    async move {
+                        let mut queue = std::collections::VecDeque::new();
+                        for (remote_path, is_dir) in &targets {
+                            let target = dir_path.join(files_basename(remote_path));
+                            if *is_dir {
+                                queue.push_back(crate::state::TransferItem {
+                                    src: remote_path.clone(),
+                                    dst: target.to_string_lossy().into_owned(),
+                                    is_dir: true,
+                                    size: None,
+                                });
+                                crate::sftp_helpers::walk_remote_for_download(
+                                    &client,
+                                    remote_path,
+                                    &target,
+                                    &mut queue,
+                                )
+                                .await?;
+                            } else {
+                                queue.push_back(crate::state::TransferItem {
+                                    src: remote_path.clone(),
+                                    dst: target.to_string_lossy().into_owned(),
+                                    is_dir: false,
+                                    size: client.stat(remote_path).await.ok().map(|s| s.size),
+                                });
+                            }
+                        }
+                        if queue.is_empty() {
+                            return Ok(None);
+                        }
+                        let clients = crate::sftp_helpers::build_client_pool(client, concurrency)
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        Ok(Some(crate::state::TransferState::new(
+                            crate::state::TransferKind::Download,
+                            label.clone(),
+                            queue,
+                            clients,
+                            None,
+                            None,
+                            concurrency,
+                        )))
+                    },
+                    move |state| match state {
+                        // The envelope is what makes the pane the owner:
+                        // it stamps `routing_sftp`, so the runner's
+                        // accessors resolve to this pane's slot instead of
+                        // whatever SFTP surface happens to be focused.
+                        Ok(Some(state)) => Message::SftpFor(
+                            pane_id,
+                            Box::new(SftpMessage::SftpTransferQueueReady(pane_id, state)),
+                        ),
+                        Ok(None) => Message::NoOp,
+                        Err(e) => Message::SidebarFiles(SidebarFilesMessage::SidebarFilesOpToast(e)),
+                    },
+                )
+            }
             SidebarFilesMessage::SidebarFilesDownloadPicked(pane_id, path, dest, size) => {
                 // The dialog resolved later, so the pane is resolved by
                 // id like any completion: the user is free to switch tabs

--- a/crates/oryxis-app/src/keynav/slots.rs
+++ b/crates/oryxis-app/src/keynav/slots.rs
@@ -529,6 +529,24 @@ impl crate::app::Oryxis {
         )
     }
 
+    /// Owned-label sibling of [`Self::menu_item`]: for labels built at
+    /// render time (counts, substitutions). The label `String` moves
+    /// into the returned element, so there is no borrow to dangle.
+    pub(crate) fn menu_item_owned(
+        &self,
+        icon: impl Into<crate::os_icon::BrandIcon>,
+        label: String,
+        msg: Message,
+        color: iced::Color,
+    ) -> iced::Element<'static, Message> {
+        self.modal_nav_slot(
+            RowAction::activate(msg.clone()),
+            4.0,
+            false,
+            crate::widgets::context_menu_item_owned(icon, label, msg, color),
+        )
+    }
+
     /// Clear the Settings content recording. Each Settings section
     /// view calls this at the top of its render pass, then records
     /// its actionable rows through `settings_nav_slot`.

--- a/crates/oryxis-app/src/messages/sidebar_files.rs
+++ b/crates/oryxis-app/src/messages/sidebar_files.rs
@@ -70,6 +70,13 @@ pub enum SidebarFilesMessage {
     /// then the confirmed op (recursive for directories).
     SidebarFilesDelete(String, bool),
     SidebarFilesDeleteConfirmed(String, bool),
+    /// Bulk delete of the whole current selection (arm the same shared
+    /// confirm, count-aware copy) and its confirmed op.
+    SidebarFilesDeleteSelection(Vec<(String, bool)>),
+    SidebarFilesDeleteConfirmedSelection(Vec<(String, bool)>),
+    /// Copy every path of the current selection to the clipboard, one
+    /// per line (the SFTP pane's bulk-copy rule).
+    SidebarFilesCopySelectionPaths,
     /// Download a file to a local destination picked via the OS dialog.
     /// Only opens the dialog; a cancelled one ends the flow untouched.
     SidebarFilesDownload(String),

--- a/crates/oryxis-app/src/messages/sidebar_files.rs
+++ b/crates/oryxis-app/src/messages/sidebar_files.rs
@@ -80,6 +80,14 @@ pub enum SidebarFilesMessage {
     /// Download a file to a local destination picked via the OS dialog.
     /// Only opens the dialog; a cancelled one ends the flow untouched.
     SidebarFilesDownload(String),
+    /// Bulk download of the whole selection (files and folders) into a
+    /// directory picked via the OS dialog.
+    SidebarFilesDownloadSelection,
+    /// The folder dialog returned a destination: enqueue every selected
+    /// entry under it. Payload: pane id, destination directory, the
+    /// selected `(remote path, is_dir)` targets (directories walk
+    /// recursively like the SFTP pane's batch download).
+    SidebarFilesDownloadSelectionPicked(Uuid, String, Vec<(String, bool)>),
     /// The save dialog returned a destination: enqueue the download on
     /// the pane's own runner. Payload: pane id, remote path, local
     /// destination file, and the size the listing reported when the row

--- a/crates/oryxis-app/src/sftp_helpers.rs
+++ b/crates/oryxis-app/src/sftp_helpers.rs
@@ -121,6 +121,50 @@ pub(crate) fn ensure_local_space(dir: &std::path::Path, need: u64) -> Result<(),
 
 /// Join a basename onto a POSIX directory path, handling the root case
 /// (which would otherwise produce `//foo`).
+/// Title + detail for a "Delete" confirmation, from the targets it
+/// acts on. A single target shows its name and, for a directory, the
+/// recursive hint; a bulk delete shows the count and the folder-vs-file
+/// breakdown, so the blast radius is on screen before the button is.
+///
+/// ONE owner because two surfaces ask the same question and answer it
+/// on different widgets: the dual-pane SFTP modal (`delete_confirm_modal`)
+/// and the sidebar Files browser's `ErrorDialog`. The wording lived in
+/// the first and was copied verbatim into the second, which is how the
+/// two drift the next time a plural or a locale is fixed in only one.
+pub(crate) fn delete_confirm_copy(targets: &[(&str, bool)]) -> (String, String) {
+    use crate::i18n::t;
+    if let [(path, is_dir)] = targets {
+        let name = path
+            .rsplit(['/', '\\'])
+            .find(|s| !s.is_empty())
+            .unwrap_or(path);
+        let detail = if *is_dir {
+            format!("\"{}\", {}", name, t("folder_and_contents"))
+        } else {
+            format!("\"{name}\"")
+        };
+        return (t("delete_item_question").to_string(), detail);
+    }
+    let folders = targets.iter().filter(|(_, d)| *d).count();
+    let files = targets.len() - folders;
+    let detail = match (folders, files) {
+        (0, n) => format!("{} {}", n, t("files_lower")),
+        (n, 0) => format!("{} {}", n, t("folders_recursive_lower")),
+        (f, fi) => format!(
+            "{} {} {} {} {}",
+            f,
+            t("folders_recursive_lower"),
+            t("and"),
+            fi,
+            t("files_lower"),
+        ),
+    };
+    (
+        t("delete_n_items_question").replacen("{n}", &targets.len().to_string(), 1),
+        detail,
+    )
+}
+
 pub(crate) fn remote_join(dir: &str, basename: &str) -> String {
     if dir == "/" {
         format!("/{}", basename)

--- a/crates/oryxis-app/src/state/tabs/pane.rs
+++ b/crates/oryxis-app/src/state/tabs/pane.rs
@@ -323,9 +323,15 @@ pub(crate) struct PaneFiles {
     pub nav_replay: bool,
     /// Whether the path combo-box dropdown is open.
     pub path_history_open: bool,
-    /// Full remote path of the currently selected row, if any.
-    /// Cleared on navigation / mount / disconnect.
-    pub selected: Option<String>,
+    /// Full paths of the selected rows (the SFTP pane's multi-select
+    /// rule): a plain click selects one, Ctrl/Cmd-click toggles,
+    /// Shift-click extends a range from `selection_anchor`. Cleared on
+    /// navigation / mount / disconnect.
+    pub selected: Vec<String>,
+    /// Anchor row for shift-click range selection (mirrors the SFTP
+    /// pane's `selection_anchor`); follows the last click that set a
+    /// single selection or toggled a row.
+    pub selection_anchor: Option<String>,
     /// Timestamp + path of the last single click, for double-click
     /// detection (matching the SFTP pane's rule).
     pub last_click: Option<(std::time::Instant, String)>,
@@ -372,7 +378,8 @@ impl PaneFiles {
         // end of it.
         self.path_history.clear();
         self.path_history_open = false;
-        self.selected = None;
+        self.selected.clear();
+        self.selection_anchor = None;
         self.last_click = None;
     }
 

--- a/crates/oryxis-app/src/views/layout/menu_vault.rs
+++ b/crates/oryxis-app/src/views/layout/menu_vault.rs
@@ -38,6 +38,18 @@ impl Oryxis {
                 Message::SidebarFiles(SidebarFilesMessage::SidebarFilesCopySelectionPaths),
                 secondary,
             ));
+            // A local browser has nothing to download (issue #145), the
+            // same gate the single-file download applies.
+            if !self.sidebar_files_is_local() {
+                let download_label =
+                    crate::i18n::t("download_n_items").replacen("{n}", &n.to_string(), 1);
+                items = items.push(self.menu_item_owned(
+                    iced_fonts::lucide::download(),
+                    download_label,
+                    Message::SidebarFiles(SidebarFilesMessage::SidebarFilesDownloadSelection),
+                    OryxisColors::t().accent,
+                ));
+            }
             let delete_label =
                 crate::i18n::t("delete_n_items").replacen("{n}", &n.to_string(), 1);
             items = items.push(self.menu_item_owned(

--- a/crates/oryxis-app/src/views/layout/menu_vault.rs
+++ b/crates/oryxis-app/src/views/layout/menu_vault.rs
@@ -14,6 +14,40 @@ impl Oryxis {
         path: String,
         is_dir: bool,
     ) -> Element<'_, Message> {
+        let secondary = OryxisColors::t().text_secondary;
+        // A multi-selection (SFTP pane's rule): the menu collapses to
+        // the bulk actions that make sense over a whole selection. The
+        // selection is whatever the right-click kept; the builder runs
+        // at render time, right after `ShowSidebarFilesRowMenu` decided
+        // it, so it is in sync with the highlighted rows.
+        let multi = self.sidebar_files_multi(&path);
+        if multi {
+            let selection = self
+                .active_tab
+                .and_then(|i| self.tabs.get(i))
+                .map(|t| t.active())
+                .map(|p| crate::dispatch_sidebar_files::selected_items(&p.files))
+                .unwrap_or_default();
+            let n = selection.len();
+            let mut items = column![];
+            let copy_label =
+                crate::i18n::t("copy_n_paths").replacen("{n}", &n.to_string(), 1);
+            items = items.push(self.menu_item_owned(
+                iced_fonts::lucide::clipboard_copy(),
+                copy_label,
+                Message::SidebarFiles(SidebarFilesMessage::SidebarFilesCopySelectionPaths),
+                secondary,
+            ));
+            let delete_label =
+                crate::i18n::t("delete_n_items").replacen("{n}", &n.to_string(), 1);
+            items = items.push(self.menu_item_owned(
+                iced_fonts::lucide::trash(),
+                delete_label,
+                Message::SidebarFiles(SidebarFilesMessage::SidebarFilesDeleteSelection(selection)),
+                OryxisColors::t().error,
+            ));
+            return items.into();
+        }
         // Directory the "Open SFTP session here" lands on: the
         // folder itself, or a file's containing folder.
         let sftp_dir = if is_dir {
@@ -23,7 +57,6 @@ impl Oryxis {
                 .unwrap_or_else(|| "/".to_string())
         };
         let name = crate::dispatch_sidebar_files::files_basename(&path);
-        let secondary = OryxisColors::t().text_secondary;
         // A local browser (issue #145): transfers, edit-in-place, the
         // dual-pane promote and chmod-properties have no local meaning;
         // files open with the OS instead.

--- a/crates/oryxis-app/src/views/layout/menus.rs
+++ b/crates/oryxis-app/src/views/layout/menus.rs
@@ -134,15 +134,21 @@ impl Oryxis {
             OverlayContent::ChatConversationActions(_) => 4.0,
             OverlayContent::SessionLogViewerActions(_) => 4.0,
             OverlayContent::SftpTabActions(_) => 6.0,
-            OverlayContent::SidebarFilesRow { is_dir, .. } => {
+            OverlayContent::SidebarFilesRow { path, is_dir, .. } => {
                 // The local browser's menu (issue #145) swaps the
                 // transfer-shaped items for OS ones; counted next to
-                // the builder (`build_menu_sidebar_files_row`).
-                match (self.sidebar_files_is_local(), *is_dir) {
-                    (true, true) => 5.0,
-                    (true, false) => 6.0,
-                    (false, true) => 7.0,
-                    (false, false) => 8.0,
+                // the builder (`build_menu_sidebar_files_row`). A
+                // multi-selection collapses to Copy N paths + Delete N
+                // items.
+                if self.sidebar_files_multi(path) {
+                    2.0
+                } else {
+                    match (self.sidebar_files_is_local(), *is_dir) {
+                        (true, true) => 5.0,
+                        (true, false) => 6.0,
+                        (false, true) => 7.0,
+                        (false, false) => 8.0,
+                    }
                 }
             }
             OverlayContent::SidebarFilesBackground { .. } => {

--- a/crates/oryxis-app/src/views/layout/menus.rs
+++ b/crates/oryxis-app/src/views/layout/menus.rs
@@ -141,7 +141,14 @@ impl Oryxis {
                 // multi-selection collapses to Copy N paths + Delete N
                 // items.
                 if self.sidebar_files_multi(path) {
-                    2.0
+                    // Copy N paths (+ Download N items on a remote
+                    // browser) + Delete N items; the download row is
+                    // the same local/remote gate the builder applies.
+                    if self.sidebar_files_is_local() {
+                        2.0
+                    } else {
+                        3.0
+                    }
                 } else {
                     match (self.sidebar_files_is_local(), *is_dir) {
                         (true, true) => 5.0,

--- a/crates/oryxis-app/src/views/sftp/modals.rs
+++ b/crates/oryxis-app/src/views/sftp/modals.rs
@@ -9,33 +9,11 @@ use iced::widget::{column, row};
 pub(crate) fn delete_confirm_modal<'a>(
     targets: &[crate::state::SftpDeleteTarget],
 ) -> Element<'a, Message> {
-    let (title, detail) = if targets.len() == 1 {
-        let target = &targets[0];
-        let basename = target
-            .path
-            .rsplit(['/', '\\'])
-            .find(|s| !s.is_empty())
-            .unwrap_or(&target.path)
-            .to_string();
-        let detail = if target.is_dir {
-            format!("\"{}\", {}", basename, t("folder_and_contents"))
-        } else {
-            format!("\"{}\"", basename)
-        };
-        (t("delete_item_question").to_string(), detail)
-    } else {
-        let folder_count = targets.iter().filter(|t| t.is_dir).count();
-        let file_count = targets.len() - folder_count;
-        let detail = match (folder_count, file_count) {
-            (0, n) => format!("{} {}", n, t("files_lower")),
-            (n, 0) => format!("{} {}", n, t("folders_recursive_lower")),
-            (f, fi) => format!("{} {} {} {} {}", f, t("folders_recursive_lower"), t("and"), fi, t("files_lower")),
-        };
-        (
-            t("delete_n_items_question").replacen("{n}", &targets.len().to_string(), 1),
-            detail,
-        )
-    };
+    let owned: Vec<(&str, bool)> = targets
+        .iter()
+        .map(|t| (t.path.as_str(), t.is_dir))
+        .collect();
+    let (title, detail) = crate::sftp_helpers::delete_confirm_copy(&owned);
     let dialog = container(
         column![
             text(title).size(16).color(OryxisColors::t().text_primary),

--- a/crates/oryxis-app/src/views/sidebar_files.rs
+++ b/crates/oryxis-app/src/views/sidebar_files.rs
@@ -280,6 +280,7 @@ impl Oryxis {
                     up,
                     None,
                     false,
+                    false,
                     pos,
                 ));
                 pos += 1;
@@ -344,7 +345,7 @@ impl Oryxis {
                 } else {
                     Message::Sftp(SftpMessage::SftpCopyPath(full.clone()))
                 };
-                let is_selected = files.selected.as_deref() == Some(full.as_str());
+                let is_selected = files.selected.iter().any(|s| s == &full);
                 list = list.push(self.files_row(
                     &entry.name,
                     entry.is_dir,
@@ -354,6 +355,7 @@ impl Oryxis {
                     key_activate,
                     Some(full),
                     is_selected,
+                    is_selected && files.selected.len() > 1,
                     pos,
                 ));
                 pos += 1;
@@ -476,6 +478,10 @@ impl Oryxis {
     /// records `key_activate` (Enter = the direct action: folders
     /// navigate, files copy their path). `full_path` enables the
     /// hover-revealed Copy path action; the ".." row has none.
+    /// `multi_selected` hides that single-row copy chip: inside a
+    /// multi-selection the bulk actions live in the right-click menu,
+    /// and a chip that copied only one of several highlighted paths
+    /// would read as a surprise.
     #[allow(clippy::too_many_arguments)]
     fn files_row<'a>(
         &'a self,
@@ -487,6 +493,7 @@ impl Oryxis {
         key_activate: Message,
         full_path: Option<String>,
         selected: bool,
+        multi_selected: bool,
         pos: usize,
     ) -> Element<'a, Message> {
         let c = OryxisColors::t();
@@ -548,9 +555,10 @@ impl Oryxis {
             });
 
         // Hover-revealed floating Copy path (the card-action convention;
-        // the ring border stays the keyboard affordance).
-        let row_el: Element<'a, Message> = match (&full_path, hovered) {
-            (Some(full), true) => {
+        // the ring border stays the keyboard affordance). Hidden on a
+        // row inside a multi-selection (see `multi_selected`).
+        let row_el: Element<'a, Message> = match (&full_path, hovered, multi_selected) {
+            (Some(full), true, false) => {
                 let actions = container(action_btn(
                     iced_fonts::lucide::clipboard_copy(),
                     Message::Sftp(SftpMessage::SftpCopyPath(full.clone())),

--- a/crates/oryxis-app/src/widgets/toolbar.rs
+++ b/crates/oryxis-app/src/widgets/toolbar.rs
@@ -301,6 +301,44 @@ pub(crate) fn context_menu_item<'a>(
     .into()
 }
 
+/// Owned-label sibling of [`context_menu_item`]: the label `String` is
+/// moved into the returned element, so a label formatted at render
+/// time (counts, substitutions) doesn't need to outlive the call.
+pub(crate) fn context_menu_item_owned(
+    icon: impl Into<crate::os_icon::BrandIcon>,
+    label: String,
+    msg: Message,
+    color: Color,
+) -> Element<'static, Message> {
+    button(
+        container(
+            dir_row(vec![
+                icon.into().view(14.0, color),
+                Space::new().width(8).into(),
+                text(label).size(12).color(OryxisColors::t().text_primary).into(),
+            ])
+            .align_y(iced::Alignment::Center),
+        )
+        .width(Length::Fill)
+        .align_x(dir_align_x()),
+    )
+    .on_press(msg)
+    .width(Length::Fill)
+    .padding(Padding { top: 6.0, right: 12.0, bottom: 6.0, left: 12.0 })
+    .style(|_, status| {
+        let bg = match status {
+            BtnStatus::Hovered => OryxisColors::t().bg_hover,
+            _ => Color::TRANSPARENT,
+        };
+        button::Style {
+            background: Some(Background::Color(bg)),
+            border: Border { radius: Radius::from(4.0), ..Default::default() },
+            ..Default::default()
+        }
+    })
+    .into()
+}
+
 /// Tag-filter trigger for the host dashboard toolbar, styled like the
 /// sort button. While tags are selected the button fills accent and
 /// shows the selection count next to the glyph, so a narrowed list is


### PR DESCRIPTION
## Summary

The sidebar Files browser only supported single-select: a click
highlighted one row, and every per-row action (copy path, delete,
download) worked on that one row. The dual-pane SFTP surface has
supported multi-select all along — the sidebar, where quick file
management actually happens, did not.

This PR brings the browser up to the SFTP surface's selection
model and wires the selection through the operations that already
existed for single rows.

## Implementation

- **Selection**: `PaneFiles::selected` becomes a `Vec<String>` with
a `selection_anchor`. Plain click selects one row, Ctrl/Cmd-click
toggles, Shift-click extends a range from the anchor, and
double-click on a directory still enters it (a modified click is
never treated as an enter). Ctrl+A / Cmd+A selects every visible
row.
- **Right-click semantics** (Explorer / Finder, and the SFTP pane's
rule): right-clicking a row inside the selection keeps the whole
selection so menu actions apply to all of it; an outside row
re-selects just that row.
- **Multi-select row menu**: Copy N paths (one per line) and
Delete N items (count-aware confirm with a folder/file breakdown,
bulk delete then a single re-list).
- **Bulk download**: Download N items picks a folder instead of the
single-file save dialog; every selected entry enqueues on the
pane's own transfer runner, with folders walking recursively so
the progress bar carries real byte totals.
- **Drag-out** (issue #167): a press on a selected file row drags
the whole selection out of the window (files only, capped at 64
like the SFTP pane).
- The ring-less Delete key acts on the whole mouse selection.
- The selection is pruned on re-list (a refresh never points at
deleted rows) and cleared on navigation / disconnect / path edit.

## Scope

Sidebar Files browser only — the dual-pane SFTP surface is
untouched. Local-shell browsers get no download entries (they have
no transfer), matching the single-file gate.

## Testing

- `cargo check -p oryxis-app`
- `cargo test -p oryxis-app --bin oryxis` (948/948)
- New unit tests for selection pruning, the visible-path / range
helpers, and the multi-file drag-out payload