### PR TITLE
test(sftp-shell): a rooted local path is asserted by where it resolves

### DIFF
--- a/crates/oryxis-ssh/src/sftp_shell/exec.rs
+++ b/crates/oryxis-ssh/src/sftp_shell/exec.rs
@@ -1574,6 +1574,13 @@ mod tests {
     fn local_paths_resolve_against_the_local_directory() {
         let s = ShellState::new("/home".into(), PathBuf::from("/tmp/work"), 80);
         assert_eq!(s.resolve_local("a.txt"), PathBuf::from("/tmp/work/a.txt"));
-        assert!(s.resolve_local("/etc/hosts").is_absolute());
+        // A rooted path REPLACES the local cwd instead of being joined
+        // onto it. Asserted as the resolved path rather than through
+        // `is_absolute()`, which cannot say so on Windows: absolute
+        // means "has a drive prefix" there, so `/etc/hosts` is rooted,
+        // resolves correctly, and still answers false. The old
+        // assertion made this test fail on Windows for a path the code
+        // handles perfectly well.
+        assert_eq!(s.resolve_local("/etc/hosts"), PathBuf::from("/etc/hosts"));
     }
 }


### PR DESCRIPTION
`sftp_shell::exec::tests::local_paths_resolve_against_the_local_directory`
fails on Windows, on an assertion about a path the code handles correctly.

What the test means is that a rooted path replaces the local cwd rather than
being joined onto it. What it asked was `is_absolute()`, and on Windows
absolute means "carries a drive prefix": `/etc/hosts` has a root, no prefix,
resolves exactly as intended, and still answers false. So the assertion failed
while the behaviour it was guarding was right.

Asserted against the resolved path instead, which is the actual claim and is
true on both platforms. No production code changed.

`cargo test -p oryxis-ssh --lib` goes from 386/387 to 387/387 on Windows 11.

Fixes #211.
