### PR TITLE
fix(sftp): the new-entry dialog takes the keyboard the moment it opens

### DIFF
--- a/crates/oryxis-app/src/dispatch_sftp/entries.rs
+++ b/crates/oryxis-app/src/dispatch_sftp/entries.rs
@@ -215,6 +215,12 @@ impl Oryxis {
                     kind,
                     input: String::new(),
                 });
+                // Drop the keyboard straight into the name field, so the
+                // right-click flows into typing the name. Same courtesy the
+                // inline rename above and the sidebar's new-entry row do.
+                return Ok(crate::widgets::focus_input(iced::widget::Id::new(
+                    crate::views::sftp::NEW_ENTRY_INPUT_ID,
+                )));
             }
             SftpMessage::SftpNewEntryInput(s) => {
                 if let Some(ref mut e) = self.sftp.new_entry {

--- a/crates/oryxis-app/src/views/sftp/modals.rs
+++ b/crates/oryxis-app/src/views/sftp/modals.rs
@@ -130,6 +130,9 @@ pub(crate) fn close_guard_modal<'a>() -> Element<'a, Message> {
         .into()
 }
 
+/// Widget id of the new-entry name input, focused when the modal opens.
+pub(crate) const NEW_ENTRY_INPUT_ID: &str = "sftp-new-entry-input";
+
 /// Modal for "New folder" / "New file", single text input + create/cancel.
 /// `Enter` in the input commits, mirroring the inline rename behaviour.
 pub(crate) fn new_entry_modal<'a>(entry: &'a crate::state::SftpNewEntry) -> Element<'a, Message> {
@@ -146,6 +149,7 @@ pub(crate) fn new_entry_modal<'a>(entry: &'a crate::state::SftpNewEntry) -> Elem
             text(title).size(16).color(OryxisColors::t().text_primary),
             Space::new().height(12),
             text_input(placeholder, &entry.input)
+                .id(iced::widget::Id::new(NEW_ENTRY_INPUT_ID))
                 .on_input(|v| Message::Sftp(SftpMessage::SftpNewEntryInput(v)))
                 .on_submit(Message::Sftp(SftpMessage::SftpNewEntryCommit))
                 .padding(10)


### PR DESCRIPTION
Right-click > New folder (or New file) in the SFTP browser raises the dialog
but leaves focus where it was, so the name has to be clicked before it can be
typed. The expected flow is right-click, then type.

The inline rename has dropped the keyboard into its field since it was written
(`dispatch_sftp/entries.rs`), and the sidebar's own new-entry row does the same
(`dispatch_sidebar_files/entries.rs`). The SFTP modal was the one creation path
that did not, and the reason is that its `text_input` carried no widget id at
all, so there was nothing to focus.

Given one, and the `SftpStartNewEntry` arm now hands back the same
`focus_input` task the rename arm returns.

No new strings, and no new surface: `Modal::SftpNewEntry` was already
registered for Esc handling.

`cargo check` / `cargo clippy --workspace --all-targets -- -D warnings` /
`cargo test --workspace --lib --bins` clean on Windows 11.

Fixes #210.
