### PR TITLE
feat(terminal): a pane can leave its grid, into its own tab or another

### DIFF
--- a/crates/oryxis-app/src/app.rs
+++ b/crates/oryxis-app/src/app.rs
@@ -1322,13 +1322,10 @@ pub struct Oryxis {
     /// handle there (issue #208 item 4). Recorded when the widget picks
     /// the pane up, read when it reports the release.
     ///
-    /// Not derivable at release time, and both halves are the reason.
-    /// A `pane_grid::Pane` handle is minted per grid and is only unique
-    /// within one, so the tab cannot be found by searching for it. And
-    /// `active_tab` cannot stand in: the release that ends the drag also
-    /// reaches the destination chip's own button, which publishes on the
-    /// RELEASE rather than the press, so by the time the drag event is
-    /// handled the active tab may already BE the destination.
+    /// Not derivable at release time: a `pane_grid::Pane` handle is
+    /// minted per grid and is only unique within one, so the tab cannot
+    /// be found by searching for the handle, and the handle only means
+    /// something next to the tab it was minted in.
     pub(crate) pane_drag_from: Option<(uuid::Uuid, iced::widget::pane_grid::Pane)>,
     /// Live width of the right-side editor drawer (host / key / identity /
     /// snippet / port-forward / cloud forms, all of them: they share one

--- a/crates/oryxis-app/src/app.rs
+++ b/crates/oryxis-app/src/app.rs
@@ -1318,6 +1318,18 @@ pub struct Oryxis {
     pub(crate) pending_ecs_autoconnect: Option<crate::state::PendingEcsAutoConnect>,
     /// In-progress tab reorder drag (see `TabDrag`). `None` when not dragging.
     pub(crate) tab_drag: Option<crate::state::TabDrag>,
+    /// Which tab a pane being dragged by its header came FROM, and its
+    /// handle there (issue #208 item 4). Recorded when the widget picks
+    /// the pane up, read when it reports the release.
+    ///
+    /// Not derivable at release time, and both halves are the reason.
+    /// A `pane_grid::Pane` handle is minted per grid and is only unique
+    /// within one, so the tab cannot be found by searching for it. And
+    /// `active_tab` cannot stand in: the release that ends the drag also
+    /// reaches the destination chip's own button, which publishes on the
+    /// RELEASE rather than the press, so by the time the drag event is
+    /// handled the active tab may already BE the destination.
+    pub(crate) pane_drag_from: Option<(uuid::Uuid, iced::widget::pane_grid::Pane)>,
     /// Live width of the right-side editor drawer (host / key / identity /
     /// snippet / port-forward / cloud forms, all of them: they share one
     /// width, like they shared one constant). Defaults to `PANEL_WIDTH`,

--- a/crates/oryxis-app/src/app_tests.rs
+++ b/crates/oryxis-app/src/app_tests.rs
@@ -414,3 +414,92 @@ fn every_pane_end_action_has_its_own_label() {
         }
     }
 }
+
+/// Breaking a pane out is a MOVE, so the pane arrives whole: the same
+/// session-log row, the same origin, the same terminal. A close would
+/// end all three, and the difference between the two paths is the whole
+/// point of issue #208 item 4.
+#[test]
+fn a_pane_broken_out_keeps_what_it_owns() {
+    use crate::state::{LocalShellSpec, PaneOrigin, TerminalTab};
+
+    let terminal = std::sync::Arc::new(std::sync::Mutex::new(
+        oryxis_terminal::TerminalState::new_no_pty(80, 24).expect("terminal"),
+    ));
+    let mut pane = crate::state::Pane::new("host-b".to_string(), terminal);
+    let log_id = uuid::Uuid::new_v4();
+    let pane_id = pane.id;
+    pane.session_log_id = Some(log_id);
+    pane.origin = PaneOrigin::Local(LocalShellSpec {
+        label: "PowerShell".into(),
+        program: "powershell.exe".into(),
+        args: Vec::new(),
+    });
+
+    let tab = TerminalTab::adopting(pane);
+    assert_eq!(tab.pane_count(), 1);
+    let landed = tab.active();
+    assert_eq!(landed.id, pane_id, "the pane was rebuilt instead of moved");
+    assert_eq!(
+        landed.session_log_id,
+        Some(log_id),
+        "the recording was ended or restarted",
+    );
+    assert!(
+        matches!(landed.origin, PaneOrigin::Local(_)),
+        "the pane forgot what it reconnects to",
+    );
+    // The new tab is named by the pane, the way an unsplit tab always is.
+    assert_eq!(tab.label, "host-b");
+    // Everything the SOURCE tab owned stays with the source.
+    assert!(!tab.pinned, "a pin followed a pane out of its tab");
+    assert!(tab.relaunch.is_none(), "a relaunch spec followed a pane out");
+    assert!(tab.session_group_id.is_none(), "group membership followed a pane out");
+    assert!(!tab.broadcast, "broadcast followed a pane into a tab of one");
+}
+
+/// What a tab owes when a pane LEAVES it, whichever way it left. Closing
+/// and moving share `take_pane` precisely so these three cannot drift
+/// apart, and each of them was its own bug once.
+#[test]
+fn a_tab_settles_when_a_pane_leaves_it() {
+    use crate::state::TerminalTab;
+
+    fn pane(label: &str) -> crate::state::Pane {
+        crate::state::Pane::new(
+            label.to_string(),
+            std::sync::Arc::new(std::sync::Mutex::new(
+                oryxis_terminal::TerminalState::new_no_pty(80, 24).expect("terminal"),
+            )),
+        )
+    }
+
+    let mut tab = TerminalTab::adopting(pane("first"));
+    let first = tab.focused;
+    let (second, _) = tab
+        .pane_grid
+        .split(iced::widget::pane_grid::Axis::Vertical, first, pane("second"))
+        .expect("split");
+    // Armed while it was a split, which is the only time it can be.
+    tab.broadcast = true;
+    tab.focused = second;
+    assert!(tab.broadcast_capable());
+
+    // The FOCUSED pane leaves.
+    let taken = tab.take_pane(second).expect("the pane");
+    assert_eq!(taken.label, "second");
+    assert_eq!(tab.focused, first, "focus did not follow to the survivor");
+    assert!(!tab.broadcast, "broadcast stayed armed on a tab that cannot show it");
+    assert_eq!(tab.label, "first", "the tab kept the name of the pane that left");
+
+    // A background pane leaving must NOT move the keyboard.
+    let mut tab = TerminalTab::adopting(pane("first"));
+    let first = tab.focused;
+    let (second, _) = tab
+        .pane_grid
+        .split(iced::widget::pane_grid::Axis::Vertical, first, pane("second"))
+        .expect("split");
+    tab.focused = first;
+    let _ = tab.take_pane(second);
+    assert_eq!(tab.focused, first, "closing a background pane yanked the keyboard");
+}

--- a/crates/oryxis-app/src/app_tests.rs
+++ b/crates/oryxis-app/src/app_tests.rs
@@ -503,3 +503,4 @@ fn a_tab_settles_when_a_pane_leaves_it() {
     let _ = tab.take_pane(second);
     assert_eq!(tab.focused, first, "closing a background pane yanked the keyboard");
 }
+

--- a/crates/oryxis-app/src/boot/mod.rs
+++ b/crates/oryxis-app/src/boot/mod.rs
@@ -561,6 +561,7 @@ impl Oryxis {
                 pin_next_plugin_tab: None,
                 pending_ecs_autoconnect: None,
                 tab_drag: None,
+                pane_drag_from: None,
                 panel_width: crate::app::PANEL_WIDTH,
                 panel_resize_drag: None,
                 editor_saved_snapshot: None,

--- a/crates/oryxis-app/src/dispatch_tabs/merge.rs
+++ b/crates/oryxis-app/src/dispatch_tabs/merge.rs
@@ -102,6 +102,95 @@ impl Oryxis {
         Some((dest_idx, proposal))
     }
 
+    /// Move one pane into the tab whose chip the cursor is over, if it is
+    /// over one (issue #208 item 4). Answers whether it moved.
+    ///
+    /// The inverse of the gesture above, and it reads the same way round:
+    /// there, a whole tab is dragged onto a grid to become panes; here,
+    /// one pane is dragged onto a chip to join that tab. Both are moves,
+    /// so neither tears a session down.
+    ///
+    /// A chip says WHICH tab and nothing about where in it, so the pane
+    /// lands on the destination's trailing edge: predictable without
+    /// having to know which pane happens to be focused in a tab that is
+    /// not on screen. The cursor cannot say more than that, and guessing
+    /// would be worse than a rule.
+    ///
+    /// `from` is the tab the drag STARTED in, recorded when the widget
+    /// picked the pane up, because neither the handle nor `active_tab`
+    /// can name it by now: see `Oryxis::pane_drag_from`.
+    pub(crate) fn move_pane_to_hovered_tab(
+        &mut self,
+        from: Option<(uuid::Uuid, PaneHandle)>,
+        handle: PaneHandle,
+    ) -> bool {
+        if !self.cursor_in_tab_strip() {
+            return false;
+        }
+        let Some((src_id, picked)) = from else {
+            return false;
+        };
+        // The widget reports the pane it released; it must be the one it
+        // told us it had picked up, or the record is from another drag.
+        if picked != handle {
+            return false;
+        }
+        let (Some(dest_idx), Some(src_idx)) =
+            (self.hover.tab, self.tabs.iter().position(|t| t._id == src_id))
+        else {
+            return false;
+        };
+        // Onto its own chip is a no-op, not a move to nowhere.
+        if dest_idx == src_idx {
+            return false;
+        }
+        let Some(dest) = self.tabs.get(dest_idx) else {
+            return false;
+        };
+        // A dormant pinned tab is a placeholder carrying a reopen spec,
+        // not a grid; there is nothing to join yet.
+        if dest.pending_reopen.is_some() {
+            return false;
+        }
+        let Some(src) = self.tabs.get(src_idx) else {
+            return false;
+        };
+        // The last pane of a tab cannot leave this way: the tab would be
+        // left empty, and the gesture cannot start on it anyway (a lone
+        // pane grows no header, so there is no handle to drag).
+        if src.pane_count() <= 1 {
+            return false;
+        }
+        let keepalive = src.ssm_keepalive;
+        // Flushed while the pane's own tab still owns the bookkeeping.
+        // Nothing is ending: the log id travels and keeps writing to the
+        // row it already had.
+        self.flush_session_logs_final();
+        let Some(pane) = self.tabs[src_idx].take_pane(handle) else {
+            return false;
+        };
+        let dest = &mut self.tabs[dest_idx];
+        // Per TAB rather than per pane, so a pane arriving from a
+        // keepalive tab would otherwise start idling out.
+        dest.ssm_keepalive |= keepalive;
+        let landed = insert_panes(
+            &mut dest.pane_grid,
+            Target::Edge(Edge::Right),
+            vec![pane],
+        );
+        // The arriving pane takes the destination's focus, so switching
+        // to that tab lands on what was just put there.
+        if let Some(first) = landed.first() {
+            dest.focused = *first;
+        }
+        // `active_tab` is not set here, and the view still follows the
+        // pane: the release that ended the drag also reaches the chip's
+        // own button, which selects that tab. Setting it as well would be
+        // a second opinion about the same click, and the chip's is the
+        // one that would win anyway.
+        true
+    }
+
     /// Perform the proposed drop: move every pane of the dragged tab into
     /// the displayed tab's grid and retire the source chip.
     ///
@@ -218,7 +307,7 @@ fn detach_panes_in_layout_order(
 /// on its trailing side. Chaining forwards (rather than repeating the
 /// target) is what keeps a multi-pane source in its original
 /// left-to-right order even when it lands on a leading edge.
-fn insert_panes(
+pub(crate) fn insert_panes(
     grid: &mut iced::widget::pane_grid::State<crate::state::Pane>,
     target: Target,
     panes: Vec<crate::state::Pane>,
@@ -386,5 +475,65 @@ mod tests {
         let detached = detach_panes_in_layout_order(source);
         let order: Vec<&str> = detached.iter().map(|p| p.label.as_str()).collect();
         assert_eq!(order, ["second", "first"]);
+    }
+
+    /// A pane arriving from ANOTHER tab (issue #208 item 4) joins on the
+    /// trailing edge and keeps what it owns, and the source settles
+    /// behind it. The inverse of the drop above, and neither is a close,
+    /// so the session, its recording and its origin all survive the trip.
+    #[test]
+    fn a_pane_moved_between_tabs_lands_whole_on_the_trailing_edge() {
+        use crate::state::{PaneOrigin, TerminalTab};
+
+        fn tab_labels(tab: &TerminalTab) -> Vec<String> {
+            let regions = tab
+                .pane_grid
+                .layout()
+                .pane_regions(0.0, 50.0, Size::new(4096.0, 4096.0));
+            let mut order: Vec<_> = regions.into_iter().collect();
+            order.sort_by(|(_, a), (_, b)| a.y.total_cmp(&b.y).then(a.x.total_cmp(&b.x)));
+            order
+                .iter()
+                .filter_map(|(h, _)| tab.pane_grid.panes.get(h).map(|p| p.label.clone()))
+                .collect()
+        }
+
+        // Source: two panes, the second carrying state that must travel.
+        let mut src = TerminalTab::adopting(pane("keep"));
+        let first = src.focused;
+        let mut leaving = pane("leaving");
+        let log_id = uuid::Uuid::new_v4();
+        let leaving_id = leaving.id;
+        leaving.session_log_id = Some(log_id);
+        leaving.origin = PaneOrigin::Host(uuid::Uuid::new_v4());
+        let (second, _) = src
+            .pane_grid
+            .split(Axis::Vertical, first, leaving)
+            .expect("split");
+        src.focused = second;
+
+        let mut dest = TerminalTab::adopting(pane("dest"));
+
+        let taken = src.take_pane(second).expect("the pane");
+        let landed = insert_panes(&mut dest.pane_grid, Target::Edge(Edge::Right), vec![taken]);
+
+        assert_eq!(
+            tab_labels(&dest),
+            ["dest", "leaving"],
+            "did not land on the trailing edge",
+        );
+        let arrived = dest
+            .pane_grid
+            .panes
+            .get(landed.first().expect("a landed handle"))
+            .expect("the arrived pane");
+        assert_eq!(arrived.id, leaving_id, "the pane was rebuilt instead of moved");
+        assert_eq!(arrived.session_log_id, Some(log_id), "the recording was ended");
+        assert!(matches!(arrived.origin, PaneOrigin::Host(_)), "the origin was lost");
+
+        // And the source settled behind it.
+        assert_eq!(tab_labels(&src), ["keep"]);
+        assert_eq!(src.label, "keep", "the source kept the name of the pane that left");
+        assert_eq!(src.focused, first, "focus did not follow to the survivor");
     }
 }

--- a/crates/oryxis-app/src/dispatch_tabs/merge.rs
+++ b/crates/oryxis-app/src/dispatch_tabs/merge.rs
@@ -117,8 +117,9 @@ impl Oryxis {
     /// would be worse than a rule.
     ///
     /// `from` is the tab the drag STARTED in, recorded when the widget
-    /// picked the pane up, because neither the handle nor `active_tab`
-    /// can name it by now: see `Oryxis::pane_drag_from`.
+    /// picked the pane up: a `pane_grid::Pane` handle is minted per grid
+    /// and unique only within one, so the tab cannot be found from the
+    /// handle afterwards. See `Oryxis::pane_drag_from`.
     pub(crate) fn move_pane_to_hovered_tab(
         &mut self,
         from: Option<(uuid::Uuid, PaneHandle)>,
@@ -169,6 +170,7 @@ impl Oryxis {
         let Some(pane) = self.tabs[src_idx].take_pane(handle) else {
             return false;
         };
+        let pane_id = pane.id;
         let dest = &mut self.tabs[dest_idx];
         // Per TAB rather than per pane, so a pane arriving from a
         // keepalive tab would otherwise start idling out.
@@ -183,11 +185,22 @@ impl Oryxis {
         if let Some(first) = landed.first() {
             dest.focused = *first;
         }
-        // `active_tab` is not set here, and the view still follows the
-        // pane: the release that ended the drag also reaches the chip's
-        // own button, which selects that tab. Setting it as well would be
-        // a second opinion about the same click, and the chip's is the
-        // one that would win anyway.
+        // A pane still dialling keeps its connect screen, and that
+        // screen is drawn over the TAB the progress names, so the
+        // progress has to name the tab the pane is in now or the dial
+        // keeps covering the tab it left.
+        if let Some(progress) = self.connecting.as_mut()
+            && progress.pane_id == pane_id
+        {
+            progress.tab_idx = dest_idx;
+        }
+        // The view follows the pane, and nothing else makes it: the
+        // chip is a `button`, and a button only publishes on a release
+        // whose PRESS began on it, which this one did not (it began on
+        // the pane's header). Same landing the tab-into-grid drop above
+        // gives the panes it moves.
+        self.active_tab = Some(dest_idx);
+        self.remember_terminal_tab_focus(dest_idx);
         true
     }
 

--- a/crates/oryxis-app/src/dispatch_terminal/mod.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/mod.rs
@@ -239,11 +239,33 @@ impl Oryxis {
                 }
             }
             TerminalMessage::PaneDrag(ev) => {
-                // Only the drop carries anything to do. `Picked` and
-                // `Canceled` describe a gesture the WIDGET is already
-                // tracking in its own `Action::Dragging`, including the
-                // preview it paints, so answering them would be a second
-                // opinion about a drag we do not own.
+                // `Canceled` is the release that landed on no pane, which
+                // is also the release that landed on the TAB STRIP. If a
+                // chip was under it the pane joins that tab (issue #208
+                // item 4); anywhere else it stays where it is, which is
+                // what the widget already means by cancelling.
+                //
+                // `Picked` only records where the pane came from. The
+                // drag itself is still entirely the widget's, preview
+                // included; what cannot be recovered later is the SOURCE.
+                // A pane handle is minted per grid and unique only within
+                // one, and `active_tab` is no help either: this release
+                // also reaches the destination chip's button, which fires
+                // on the release rather than the press, so the active tab
+                // may already be the destination by now.
+                if let iced::widget::pane_grid::DragEvent::Picked { pane } = ev {
+                    if let Some(id) = self.active_tab.and_then(|i| self.tabs.get(i)).map(|t| t._id)
+                    {
+                        self.pane_drag_from = Some((id, pane));
+                    }
+                    return Task::none();
+                }
+                if let iced::widget::pane_grid::DragEvent::Canceled { pane } = ev {
+                    let from = self.pane_drag_from.take();
+                    self.move_pane_to_hovered_tab(from, pane);
+                    return Task::none();
+                }
+                self.pane_drag_from = None;
                 if let iced::widget::pane_grid::DragEvent::Dropped { pane, target } = ev
                     && let Some(tab_idx) = self.active_tab
                     && let Some(tab) = self.tabs.get_mut(tab_idx)

--- a/crates/oryxis-app/src/dispatch_terminal/mod.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/mod.rs
@@ -747,6 +747,16 @@ impl Oryxis {
                     None => paste_trace("resolved", "clipboard unavailable", "", None),
                 }
             }
+            TerminalMessage::ShowPaneHeaderMenu(pane_id) => {
+                // Anchored on the tracked cursor, which is where the
+                // press was: a `MouseArea` reports the button, not the
+                // point. No selection travels, because the header is not
+                // the grid and nothing was selected by clicking it.
+                let at = self.mouse_position;
+                return self.update(Message::Terminal(
+                    TerminalMessage::ShowTerminalContextMenu(pane_id, at.x, at.y, None),
+                ));
+            }
             TerminalMessage::ShowTerminalContextMenu(pane_id, x, y, selection) => {
                 // Focus the right-clicked pane first (standard context-menu
                 // behavior), so all rows act on the same pane: Copy All /

--- a/crates/oryxis-app/src/dispatch_terminal/mod.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/mod.rs
@@ -372,28 +372,13 @@ impl Oryxis {
                         _ => None,
                     };
                 }
-                if let Some((_closed, sibling)) = tab.pane_grid.close(target) {
-                    // Only a close of the focused pane moves focus;
-                    // closing a background pane from its context menu
-                    // must not yank the keyboard to its sibling.
-                    if tab.focused == target {
-                        tab.focused = sibling;
-                    }
-                }
-                // Back to a single pane: disarm broadcast (its control
-                // surfaces are hidden for unsplit tabs, so a lingering
-                // armed state would be invisible) and drop the survivor's
-                // opt-out so a later re-arm starts clean.
-                if !tab.broadcast_capable() && tab.broadcast {
-                    tab.broadcast = false;
-                    for pane in tab.pane_grid.panes.values_mut() {
-                        pane.broadcast_opt_out = false;
-                    }
-                }
-                // A collapsed split has to re-anchor the tab on the pane
-                // that is left: the unsplit label comes from the TAB, which
-                // was named after the pane that just closed (issue #108).
-                tab.sync_label_to_sole_pane();
+                // Take the pane out and let the tab settle: focus onto the
+                // promoted sibling if the closed one held it, broadcast
+                // disarmed once the tab can no longer do it, and the label
+                // re-anchored on the survivor (issue #108). The same three
+                // repairs a pane MOVED to another tab owes, which is why
+                // they live on the tab rather than here.
+                let _ = tab.take_pane(target);
                 if let Some(log_id) = ended_log
                     && let Some(vault) = &self.vault
                 {
@@ -510,6 +495,68 @@ impl Oryxis {
                     let handle = *handle;
                     tab.flip_split_at(handle);
                 }
+            }
+            TerminalMessage::MovePaneToNewTab(pane_id) => {
+                self.overlay = None;
+                let Some(src_idx) = self.pane_tab_index(pane_id) else {
+                    return Task::none();
+                };
+                let Some(src) = self.tabs.get(src_idx) else {
+                    return Task::none();
+                };
+                // A lone pane is already a tab of its own. The menu row
+                // is only offered on a split, so this is the overlay
+                // racing a close rather than a reachable choice.
+                if src.pane_count() <= 1 {
+                    return Task::none();
+                }
+                let Some((&handle, _)) =
+                    src.pane_grid.panes.iter().find(|(_, p)| p.id == pane_id)
+                else {
+                    return Task::none();
+                };
+                let keepalive = src.ssm_keepalive;
+                // The pane's recorded output is flushed while its own tab
+                // still owns the log bookkeeping. Nothing is ENDING here,
+                // so the log id travels with the pane and keeps writing
+                // to the same row from its new tab.
+                self.flush_session_logs_final();
+                let Some(pane) = self.tabs[src_idx].take_pane(handle) else {
+                    return Task::none();
+                };
+                // Everything a close would do to the session is exactly
+                // what must NOT happen: no `session.close()`, no ended
+                // log, no `monitor_reset_host`, no `prune_quick_connects`.
+                // The pane is moving, not dying, and it carries all of
+                // that with it.
+                let mut tab = crate::state::TerminalTab::adopting(pane);
+                // An SSM / ECS session stays alive by being nudged on a
+                // timer, and the flag is per TAB, so a pane leaving a
+                // keepalive tab would quietly start idling out. Same
+                // carry `merge_dragged_tab_if_proposed` makes in the
+                // opposite direction.
+                tab.ssm_keepalive = keepalive;
+                // Beside the tab it came from, not at the far end of the
+                // strip: the pane was on screen a moment ago and the eye
+                // should not have to hunt for where it went.
+                //
+                // Armed rather than spliced. `Oryxis::tabs` is append-only
+                // by design, so that no `active_tab` / `last_terminal_tab`
+                // / `connecting.tab_idx` index goes stale; the strip's
+                // order is `tab_order`, and `place_new_tab_ref` is the one
+                // door every new tab walks through to get its slot.
+                let source_id = self.tabs[src_idx]._id;
+                self.pending_tab_placement = Some(crate::state::PendingTabPlacement {
+                    source_id,
+                    placement: crate::state::TabPlacement::NextToOriginal,
+                    armed_at: std::time::Instant::now(),
+                });
+                let dest_idx = self.tabs.len();
+                self.tabs.push(tab);
+                self.active_tab = Some(dest_idx);
+                self.remember_terminal_tab_focus(dest_idx);
+                self.active_view = crate::state::View::Terminal;
+                return self.tab_scroll_to_active();
             }
             TerminalMessage::TerminalBellFlashEnd(pane_id) => {
                 if let Some(pane) = self

--- a/crates/oryxis-app/src/dispatch_terminal/mod.rs
+++ b/crates/oryxis-app/src/dispatch_terminal/mod.rs
@@ -247,12 +247,9 @@ impl Oryxis {
                 //
                 // `Picked` only records where the pane came from. The
                 // drag itself is still entirely the widget's, preview
-                // included; what cannot be recovered later is the SOURCE.
-                // A pane handle is minted per grid and unique only within
-                // one, and `active_tab` is no help either: this release
-                // also reaches the destination chip's button, which fires
-                // on the release rather than the press, so the active tab
-                // may already be the destination by now.
+                // included; what cannot be recovered later is the SOURCE,
+                // because a pane handle is minted per grid and unique
+                // only within one.
                 if let iced::widget::pane_grid::DragEvent::Picked { pane } = ev {
                     if let Some(id) = self.active_tab.and_then(|i| self.tabs.get(i)).map(|t| t._id)
                     {
@@ -262,7 +259,9 @@ impl Oryxis {
                 }
                 if let iced::widget::pane_grid::DragEvent::Canceled { pane } = ev {
                     let from = self.pane_drag_from.take();
-                    self.move_pane_to_hovered_tab(from, pane);
+                    if self.move_pane_to_hovered_tab(from, pane) {
+                        return self.tab_scroll_to_active();
+                    }
                     return Task::none();
                 }
                 self.pane_drag_from = None;
@@ -575,6 +574,15 @@ impl Oryxis {
                 });
                 let dest_idx = self.tabs.len();
                 self.tabs.push(tab);
+                // A pane still dialling keeps its connect screen, and
+                // that screen is drawn over the TAB the progress names,
+                // so the progress has to name the tab the pane is in now
+                // or the dial keeps covering the tab it left.
+                if let Some(progress) = self.connecting.as_mut()
+                    && progress.pane_id == pane_id
+                {
+                    progress.tab_idx = dest_idx;
+                }
                 self.active_tab = Some(dest_idx);
                 self.remember_terminal_tab_focus(dest_idx);
                 self.active_view = crate::state::View::Terminal;

--- a/crates/oryxis-app/src/hotkeys/action.rs
+++ b/crates/oryxis-app/src/hotkeys/action.rs
@@ -57,6 +57,10 @@ pub enum HotkeyAction {
     /// untouched while zoomed, so restoring puts every pane back exactly
     /// where it was.
     ToggleMaximizePane,
+    /// Break the focused pane out into a tab of its own. Reachable
+    /// without a mouse, and without the Menu right-click scheme that
+    /// the pane's own context menu needs.
+    MovePaneToNewTab,
     /// Ring the terminal-sidebar list rows (Snippets / History):
     /// opens the sidebar when closed, cycles the two list tabs on
     /// repeat. Terminal-only, like the split-pane family.
@@ -177,6 +181,7 @@ impl HotkeyAction {
             FocusPaneUp,
             FocusPaneDown,
             ToggleMaximizePane,
+            MovePaneToNewTab,
             FocusSidebarList,
             ToggleSidebar,
             ToggleSidebarOther,
@@ -226,6 +231,7 @@ impl HotkeyAction {
             FocusPaneUp => "focus_pane_up",
             FocusPaneDown => "focus_pane_down",
             ToggleMaximizePane => "toggle_maximize_pane",
+            MovePaneToNewTab => "move_pane_to_new_tab",
             FocusSidebarList => "focus_sidebar_list",
             ToggleSidebar => "toggle_sidebar",
             ToggleSidebarOther => "toggle_sidebar_other",
@@ -280,6 +286,9 @@ impl HotkeyAction {
             FocusPaneUp => "hotkey_focus_pane_up",
             FocusPaneDown => "hotkey_focus_pane_down",
             ToggleMaximizePane => "hotkey_toggle_maximize_pane",
+            // Reuses the menu row's own sentence rather than minting a
+            // parallel key, the way the split actions reuse theirs.
+            MovePaneToNewTab => "pane_to_new_tab",
             FocusSidebarList => "hotkey_focus_sidebar_list",
             ToggleSidebar => "hotkey_toggle_sidebar",
             ToggleSidebarOther => "hotkey_toggle_sidebar_other",
@@ -326,6 +335,7 @@ impl HotkeyAction {
                 | FocusPaneUp
                 | FocusPaneDown
                 | ToggleMaximizePane
+                | MovePaneToNewTab
                 | FocusSidebarList
                 | ToggleSidebar
                 | ToggleSidebarOther

--- a/crates/oryxis-app/src/hotkeys/defaults.rs
+++ b/crates/oryxis-app/src/hotkeys/defaults.rs
@@ -371,16 +371,18 @@ pub fn default_bindings() -> HotkeyMap {
     // `prefix z` convention for exactly this toggle. Shift lifts it out
     // of the terminal control-sequence gate.
     put(&mut m, ToggleMaximizePane, primary_ctrl, true, false, primary_logo, Char('z'));
-    // Ctrl+Alt+D (Cmd+Alt+D on macOS), reading off Ctrl+Shift+D for a
-    // split: the same D, one modifier along, for the pane leaving
-    // rather than arriving. Ctrl+Alt because Ctrl+Shift+D is the split
-    // it echoes.
+    // Ctrl+Alt+P (Cmd+Alt+P on macOS): P for the pane leaving. Ctrl+Alt
+    // because the Ctrl+Shift family is where the split and zoom chords
+    // live, and the natural echo of Ctrl+Shift+D, Ctrl+Alt+D, belongs to
+    // the desktop on two platforms (Cmd+Alt+D shows and hides the Dock
+    // on macOS, Ctrl+Alt+D is Show Desktop on KDE), so the app would
+    // never receive it there.
     //
     // Note for international layouts: AltGr IS Ctrl+Alt on Windows, so
     // this can collide with an accented character there. Same trade
     // `ToggleSidebarOther` already makes on Ctrl+Alt+B, and every
     // binding is rebindable.
-    put(&mut m, MovePaneToNewTab, primary_ctrl, false, true, primary_logo, Char('d'));
+    put(&mut m, MovePaneToNewTab, primary_ctrl, false, true, primary_logo, Char('p'));
     // Ctrl+Shift+H (Cmd+Shift+H on macOS): Shift lifts it out of the
     // terminal control-sequence gate (plain Ctrl+H is backspace on the
     // PTY), H for the History/lists sidebar. Rebindable like the rest.

--- a/crates/oryxis-app/src/hotkeys/defaults.rs
+++ b/crates/oryxis-app/src/hotkeys/defaults.rs
@@ -371,6 +371,16 @@ pub fn default_bindings() -> HotkeyMap {
     // `prefix z` convention for exactly this toggle. Shift lifts it out
     // of the terminal control-sequence gate.
     put(&mut m, ToggleMaximizePane, primary_ctrl, true, false, primary_logo, Char('z'));
+    // Ctrl+Alt+D (Cmd+Alt+D on macOS), reading off Ctrl+Shift+D for a
+    // split: the same D, one modifier along, for the pane leaving
+    // rather than arriving. Ctrl+Alt because Ctrl+Shift+D is the split
+    // it echoes.
+    //
+    // Note for international layouts: AltGr IS Ctrl+Alt on Windows, so
+    // this can collide with an accented character there. Same trade
+    // `ToggleSidebarOther` already makes on Ctrl+Alt+B, and every
+    // binding is rebindable.
+    put(&mut m, MovePaneToNewTab, primary_ctrl, false, true, primary_logo, Char('d'));
     // Ctrl+Shift+H (Cmd+Shift+H on macOS): Shift lifts it out of the
     // terminal control-sequence gate (plain Ctrl+H is backspace on the
     // PTY), H for the History/lists sidebar. Rebindable like the rest.

--- a/crates/oryxis-app/src/i18n/ar.rs
+++ b/crates/oryxis-app/src/i18n/ar.rs
@@ -203,6 +203,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "استعادة الأجزاء",
         "hotkey_toggle_maximize_pane" => "تكبير / استعادة الجزء",
         "close_pane" => "إغلاق اللوحة",
+        "pane_to_new_tab" => "نقل إلى علامة تبويب جديدة",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "حفظ كمجموعة",
         "edit_session_group" => "تعديل المجموعة",

--- a/crates/oryxis-app/src/i18n/cs.rs
+++ b/crates/oryxis-app/src/i18n/cs.rs
@@ -206,6 +206,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Obnovit panely",
         "hotkey_toggle_maximize_pane" => "Maximalizovat / obnovit panel",
         "close_pane" => "Zavřít panel",
+        "pane_to_new_tab" => "Přesunout na novou kartu",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Uložit jako skupinu",
         "edit_session_group" => "Upravit skupinu",

--- a/crates/oryxis-app/src/i18n/de.rs
+++ b/crates/oryxis-app/src/i18n/de.rs
@@ -202,6 +202,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Bereiche wiederherstellen",
         "hotkey_toggle_maximize_pane" => "Bereich maximieren / wiederherstellen",
         "close_pane" => "Bereich schließen",
+        "pane_to_new_tab" => "In neuen Tab verschieben",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Als Gruppe speichern",
         "edit_session_group" => "Gruppe bearbeiten",

--- a/crates/oryxis-app/src/i18n/el.rs
+++ b/crates/oryxis-app/src/i18n/el.rs
@@ -206,6 +206,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Επαναφορά τμημάτων",
         "hotkey_toggle_maximize_pane" => "Μεγιστοποίηση / επαναφορά τμήματος",
         "close_pane" => "Κλείσιμο τμήματος",
+        "pane_to_new_tab" => "Μετακίνηση σε νέα καρτέλα",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Αποθήκευση ως ομάδα",
         "edit_session_group" => "Επεξεργασία ομάδας",

--- a/crates/oryxis-app/src/i18n/en.rs
+++ b/crates/oryxis-app/src/i18n/en.rs
@@ -206,6 +206,7 @@ pub(super) fn lookup(key: &str) -> &'static str {
         "restore_panes" => "Restore panes",
         "hotkey_toggle_maximize_pane" => "Maximize / restore pane",
         "close_pane" => "Close pane",
+        "pane_to_new_tab" => "Move to a new tab",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Save as group",
         "edit_session_group" => "Edit group",

--- a/crates/oryxis-app/src/i18n/es.rs
+++ b/crates/oryxis-app/src/i18n/es.rs
@@ -202,6 +202,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Restaurar paneles",
         "hotkey_toggle_maximize_pane" => "Maximizar / restaurar panel",
         "close_pane" => "Cerrar panel",
+        "pane_to_new_tab" => "Mover a una pestaña nueva",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Guardar como grupo",
         "edit_session_group" => "Editar grupo",

--- a/crates/oryxis-app/src/i18n/fa.rs
+++ b/crates/oryxis-app/src/i18n/fa.rs
@@ -203,6 +203,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "بازگرداندن پنل‌ها",
         "hotkey_toggle_maximize_pane" => "بزرگ‌نمایی / بازگرداندن پنل",
         "close_pane" => "بستن پنل",
+        "pane_to_new_tab" => "انتقال به زبانه جدید",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "ذخیره به‌عنوان گروه",
         "edit_session_group" => "ویرایش گروه",

--- a/crates/oryxis-app/src/i18n/fr.rs
+++ b/crates/oryxis-app/src/i18n/fr.rs
@@ -202,6 +202,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Restaurer les panneaux",
         "hotkey_toggle_maximize_pane" => "Agrandir / restaurer le panneau",
         "close_pane" => "Fermer le panneau",
+        "pane_to_new_tab" => "Déplacer vers un nouvel onglet",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Enregistrer comme groupe",
         "edit_session_group" => "Modifier le groupe",

--- a/crates/oryxis-app/src/i18n/he.rs
+++ b/crates/oryxis-app/src/i18n/he.rs
@@ -206,6 +206,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "שחזר חלוניות",
         "hotkey_toggle_maximize_pane" => "הגדל / שחזר חלונית",
         "close_pane" => "סגירת חלונית",
+        "pane_to_new_tab" => "העברה ללשונית חדשה",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "שמירה כקבוצה",
         "edit_session_group" => "עריכת קבוצה",

--- a/crates/oryxis-app/src/i18n/hi.rs
+++ b/crates/oryxis-app/src/i18n/hi.rs
@@ -206,6 +206,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "पैनल पुनर्स्थापित करें",
         "hotkey_toggle_maximize_pane" => "पैनल बड़ा करें / पुनर्स्थापित करें",
         "close_pane" => "पेन बंद करें",
+        "pane_to_new_tab" => "नए टैब में ले जाएँ",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "ग्रुप के रूप में सेव करें",
         "edit_session_group" => "ग्रुप एडिट करें",

--- a/crates/oryxis-app/src/i18n/id.rs
+++ b/crates/oryxis-app/src/i18n/id.rs
@@ -203,6 +203,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Pulihkan panel",
         "hotkey_toggle_maximize_pane" => "Maksimalkan / pulihkan panel",
         "close_pane" => "Tutup panel",
+        "pane_to_new_tab" => "Pindahkan ke tab baru",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Simpan sebagai grup",
         "edit_session_group" => "Edit grup",

--- a/crates/oryxis-app/src/i18n/it.rs
+++ b/crates/oryxis-app/src/i18n/it.rs
@@ -202,6 +202,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Ripristina riquadri",
         "hotkey_toggle_maximize_pane" => "Ingrandisci / ripristina riquadro",
         "close_pane" => "Chiudi riquadro",
+        "pane_to_new_tab" => "Sposta in una nuova scheda",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Salva come gruppo",
         "edit_session_group" => "Modifica gruppo",

--- a/crates/oryxis-app/src/i18n/ja.rs
+++ b/crates/oryxis-app/src/i18n/ja.rs
@@ -202,6 +202,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "ペインを元に戻す",
         "hotkey_toggle_maximize_pane" => "ペインの最大化 / 復元",
         "close_pane" => "ペインを閉じる",
+        "pane_to_new_tab" => "新しいタブへ移動",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "グループとして保存",
         "edit_session_group" => "グループを編集",

--- a/crates/oryxis-app/src/i18n/ko.rs
+++ b/crates/oryxis-app/src/i18n/ko.rs
@@ -203,6 +203,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "창 복원",
         "hotkey_toggle_maximize_pane" => "창 최대화 / 복원",
         "close_pane" => "분할 창 닫기",
+        "pane_to_new_tab" => "새 탭으로 이동",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "그룹으로 저장",
         "edit_session_group" => "그룹 편집",

--- a/crates/oryxis-app/src/i18n/pl.rs
+++ b/crates/oryxis-app/src/i18n/pl.rs
@@ -203,6 +203,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Przywróć panele",
         "hotkey_toggle_maximize_pane" => "Maksymalizuj / przywróć panel",
         "close_pane" => "Zamknij panel",
+        "pane_to_new_tab" => "Przenieś do nowej karty",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Zapisz jako grupę",
         "edit_session_group" => "Edytuj grupę",

--- a/crates/oryxis-app/src/i18n/pt_br.rs
+++ b/crates/oryxis-app/src/i18n/pt_br.rs
@@ -202,6 +202,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Restaurar painéis",
         "hotkey_toggle_maximize_pane" => "Maximizar / restaurar painel",
         "close_pane" => "Fechar painel",
+        "pane_to_new_tab" => "Mover para uma nova aba",
         // Grupos de sessão (arranjos de painéis salvos)
         "save_session_group" => "Salvar como grupo",
         "edit_session_group" => "Editar grupo",

--- a/crates/oryxis-app/src/i18n/ru.rs
+++ b/crates/oryxis-app/src/i18n/ru.rs
@@ -202,6 +202,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Восстановить панели",
         "hotkey_toggle_maximize_pane" => "Развернуть / восстановить панель",
         "close_pane" => "Закрыть панель",
+        "pane_to_new_tab" => "Переместить в новую вкладку",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Сохранить как группу",
         "edit_session_group" => "Изменить группу",

--- a/crates/oryxis-app/src/i18n/th.rs
+++ b/crates/oryxis-app/src/i18n/th.rs
@@ -206,6 +206,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "คืนค่าบานหน้าต่าง",
         "hotkey_toggle_maximize_pane" => "ขยาย / คืนค่าบานหน้าต่าง",
         "close_pane" => "ปิดเพน",
+        "pane_to_new_tab" => "ย้ายไปแท็บใหม่",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "บันทึกเป็นกลุ่ม",
         "edit_session_group" => "แก้ไขกลุ่ม",

--- a/crates/oryxis-app/src/i18n/tr.rs
+++ b/crates/oryxis-app/src/i18n/tr.rs
@@ -203,6 +203,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Bölmeleri geri yükle",
         "hotkey_toggle_maximize_pane" => "Bölmeyi büyüt / geri yükle",
         "close_pane" => "Bölmeyi kapat",
+        "pane_to_new_tab" => "Yeni sekmeye taşı",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Grup olarak kaydet",
         "edit_session_group" => "Grubu düzenle",

--- a/crates/oryxis-app/src/i18n/uk.rs
+++ b/crates/oryxis-app/src/i18n/uk.rs
@@ -203,6 +203,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Відновити панелі",
         "hotkey_toggle_maximize_pane" => "Розгорнути / відновити панель",
         "close_pane" => "Закрити панель",
+        "pane_to_new_tab" => "Перемістити в нову вкладку",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Зберегти як групу",
         "edit_session_group" => "Редагувати групу",

--- a/crates/oryxis-app/src/i18n/vi.rs
+++ b/crates/oryxis-app/src/i18n/vi.rs
@@ -203,6 +203,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "Khôi phục các khung",
         "hotkey_toggle_maximize_pane" => "Phóng to / khôi phục khung",
         "close_pane" => "Đóng khung",
+        "pane_to_new_tab" => "Chuyển sang thẻ mới",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "Lưu thành nhóm",
         "edit_session_group" => "Sửa nhóm",

--- a/crates/oryxis-app/src/i18n/zh.rs
+++ b/crates/oryxis-app/src/i18n/zh.rs
@@ -202,6 +202,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "还原窗格",
         "hotkey_toggle_maximize_pane" => "最大化 / 还原窗格",
         "close_pane" => "关闭窗格",
+        "pane_to_new_tab" => "移至新标签页",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "保存为组",
         "edit_session_group" => "编辑组",

--- a/crates/oryxis-app/src/i18n/zh_tw.rs
+++ b/crates/oryxis-app/src/i18n/zh_tw.rs
@@ -202,6 +202,7 @@ pub(super) fn lookup(key: &str) -> Option<&'static str> {
         "restore_panes" => "還原窗格",
         "hotkey_toggle_maximize_pane" => "最大化 / 還原窗格",
         "close_pane" => "關閉窗格",
+        "pane_to_new_tab" => "移至新分頁",
         // Session groups (saved split-panel arrangements)
         "save_session_group" => "儲存為群組",
         "edit_session_group" => "編輯群組",

--- a/crates/oryxis-app/src/messages/terminal.rs
+++ b/crates/oryxis-app/src/messages/terminal.rs
@@ -141,6 +141,14 @@ pub enum TerminalMessage {
     /// Nothing about the session ends, so this is not a close followed
     /// by a connect: the pane itself moves, whole.
     MovePaneToNewTab(Uuid),
+    /// Right-click on a pane's HEADER: raise that pane's context menu.
+    ///
+    /// The same menu the canvas offers, reached from a strip no terminal
+    /// setting governs, so the pane's own actions stay available with
+    /// right-click left on Paste. Carries no coordinates because a
+    /// `MouseArea` reports THAT a right press happened, not where; the
+    /// handler anchors it on the tracked cursor.
+    ShowPaneHeaderMenu(Uuid),
     /// Periodic flush of buffered session-log output to the vault.
     SessionLogFlushTick,
     /// Emitted by the terminal widget when the user right-clicks. The

--- a/crates/oryxis-app/src/messages/terminal.rs
+++ b/crates/oryxis-app/src/messages/terminal.rs
@@ -133,6 +133,14 @@ pub enum TerminalMessage {
     /// Flip the orientation of the split that separates this pane from
     /// its neighbour (stacked <-> side by side).
     FlipPaneSplit(Uuid),
+    /// Break a pane out of its split into a tab of its own (issue #208
+    /// item 4). Carries the right-clicked pane's id for the same reason
+    /// `ClosePane` does: the menu overlay is not modal, so focus and the
+    /// active tab can move out from under it.
+    ///
+    /// Nothing about the session ends, so this is not a close followed
+    /// by a connect: the pane itself moves, whole.
+    MovePaneToNewTab(Uuid),
     /// Periodic flush of buffered session-log output to the vault.
     SessionLogFlushTick,
     /// Emitted by the terminal widget when the user right-clicks. The

--- a/crates/oryxis-app/src/palette.rs
+++ b/crates/oryxis-app/src/palette.rs
@@ -94,6 +94,7 @@ fn hotkey_category(action: HotkeyAction) -> PaletteCategory {
         | VaultSectionPrev | VaultSectionNext | VaultSectionSlot => PaletteCategory::Vault,
         FontZoomIn | FontZoomOut | FontZoomReset | SplitPaneVertical | SplitPaneHorizontal
         | FocusPaneLeft | FocusPaneRight | FocusPaneUp | FocusPaneDown | ToggleMaximizePane
+        | MovePaneToNewTab
         | FocusSidebarList
         | ToggleSidebar | ToggleSidebarOther | ToggleTabFiles | ToggleBroadcastInput | TerminalCopy
         | TerminalPaste | TerminalPasteSelection | TerminalSelectAll | ScrollbackPageUp

--- a/crates/oryxis-app/src/shortcuts/keyboard.rs
+++ b/crates/oryxis-app/src/shortcuts/keyboard.rs
@@ -647,6 +647,20 @@ impl Oryxis {
             ToggleMaximizePane => {
                 Task::done(Message::Terminal(TerminalMessage::ToggleMaximizePane(None)))
             }
+            // Break the focused pane out into a tab of its own. The
+            // message names a PANE rather than a tab, so the focused one
+            // is resolved here; the handler declines a lone pane, which
+            // is already a tab of its own.
+            MovePaneToNewTab => match self
+                .active_tab
+                .and_then(|i| self.tabs.get(i))
+                .map(|t| t.active().id)
+            {
+                Some(pane_id) => Task::done(Message::Terminal(
+                    TerminalMessage::MovePaneToNewTab(pane_id),
+                )),
+                None => Task::none(),
+            },
             // Broadcast input: arm / disarm fan-out across the focused
             // tab's panes.
             ToggleBroadcastInput => match self.active_tab {

--- a/crates/oryxis-app/src/state/tabs/tab.rs
+++ b/crates/oryxis-app/src/state/tabs/tab.rs
@@ -509,7 +509,26 @@ impl TerminalTab {
     /// Build a new tab with a single pane. Split it later via
     /// `pane_grid.split(...)`.
     pub fn new_single(label: String, terminal: Arc<Mutex<TerminalState>>) -> Self {
-        let (pane_grid, focused) = pane_grid::State::new(Pane::new(label.clone(), terminal));
+        Self::adopting(Pane::new(label, terminal))
+    }
+
+    /// A tab built around a pane that ALREADY EXISTS, for one broken out
+    /// of a split (issue #208 item 4).
+    ///
+    /// The pane arrives whole: its session, its recording, its scrollback
+    /// and its origin all travel, because nothing about it is ending. The
+    /// tab takes the pane's own label, which is what `new_single` names a
+    /// fresh tab after too, so a pane that read "user@host" in the grid
+    /// reads "user@host" on its own chip.
+    ///
+    /// Everything a tab owns that the pane does not is deliberately
+    /// default: the chat, the pin, the reopen spec and the session-group
+    /// membership belong to the tab the pane LEFT, not to the pane. The
+    /// one exception is decided by the caller, which carries
+    /// `ssm_keepalive` over when the source had it.
+    pub fn adopting(pane: Pane) -> Self {
+        let label = pane.label.clone();
+        let (pane_grid, focused) = pane_grid::State::new(pane);
         Self {
             _id: Uuid::new_v4(),
             label,
@@ -925,6 +944,39 @@ impl TerminalTab {
             return name;
         }
         self.auto_label(auto_title)
+    }
+
+    /// Take a pane OUT of this tab, alive, and leave the tab consistent.
+    ///
+    /// The three repairs a shrinking grid owes, in one place because a
+    /// pane can now leave two ways: closed (`ClosePane`) or moved to
+    /// another tab (issue #208 item 4). Both owe exactly this, and only
+    /// the caller's own bookkeeping differs.
+    ///
+    /// - focus moves to the promoted sibling, but only if the pane that
+    ///   left was the focused one; closing a background pane must not
+    ///   yank the keyboard.
+    /// - broadcast disarms once the tab is no longer capable of it. Its
+    ///   controls are hidden on an unsplit tab, so an armed state left
+    ///   behind would be invisible and still fan keystrokes out.
+    /// - the label re-anchors on the survivor, because an unsplit tab is
+    ///   named by the TAB and it was named after whichever pane it was
+    ///   created for (issue #108).
+    ///
+    /// Returns the pane, or `None` if the handle names nothing.
+    pub fn take_pane(&mut self, handle: pane_grid::Pane) -> Option<Pane> {
+        let (pane, sibling) = self.pane_grid.close(handle)?;
+        if self.focused == handle {
+            self.focused = sibling;
+        }
+        if !self.broadcast_capable() && self.broadcast {
+            self.broadcast = false;
+            for pane in self.pane_grid.panes.values_mut() {
+                pane.broadcast_opt_out = false;
+            }
+        }
+        self.sync_label_to_sole_pane();
+        Some(pane)
     }
 
     /// Re-anchor the tab's own label on the pane that is left when a

--- a/crates/oryxis-app/src/views/layout/menu_vault.rs
+++ b/crates/oryxis-app/src/views/layout/menu_vault.rs
@@ -1214,6 +1214,16 @@ impl Oryxis {
                     OryxisColors::t().text_secondary,
                 ));
             }
+            // Break this pane out into a tab of its own (issue #208
+            // item 4). Above Close because it is the non-destructive
+            // half of the same idea, "this pane should not be here":
+            // one keeps the session, the other ends it.
+            items = items.push(self.menu_item(
+                iced_fonts::lucide::external_link(),
+                crate::i18n::t("pane_to_new_tab"),
+                Message::Terminal(TerminalMessage::MovePaneToNewTab(pane_id)),
+                OryxisColors::t().text_secondary,
+            ));
             items = items.push(self.menu_item(
                 iced_fonts::lucide::x(),
                 crate::i18n::t("close_pane"),

--- a/crates/oryxis-app/src/views/layout/menu_vault.rs
+++ b/crates/oryxis-app/src/views/layout/menu_vault.rs
@@ -238,6 +238,21 @@ impl Oryxis {
                 Message::Terminal(TerminalMessage::ToggleMaximizePane(Some(idx))),
                 OryxisColors::t().text_secondary,
             ));
+            // Break the focused pane out into a tab of its own (issue
+            // #208 item 4). Offered here as well as on the pane itself
+            // because the pane's own menu only exists under the Menu
+            // right-click scheme, and this action has nothing to do with
+            // what the terminal does with a right-click: a user who
+            // keeps right-click on Paste would otherwise have no way to
+            // reach it. Focused pane, like the zoom above it.
+            if let Some(pane_id) = self.tabs.get(idx).map(|t| t.active().id) {
+                items = items.push(self.menu_item(
+                    iced_fonts::lucide::external_link(),
+                    crate::i18n::t("pane_to_new_tab"),
+                    Message::Terminal(TerminalMessage::MovePaneToNewTab(pane_id)),
+                    OryxisColors::t().text_secondary,
+                ));
+            }
         }
         // Broadcast input across the tab's panes (C2): a check glyph +
         // warning tint mark the armed state, matching the pane borders and

--- a/crates/oryxis-app/src/views/terminal.rs
+++ b/crates/oryxis-app/src/views/terminal.rs
@@ -946,7 +946,7 @@ impl Oryxis {
                 .into(),
         );
 
-        let mut controls: Vec<Element<'a, Message>> = Vec::with_capacity(2);
+        let mut controls: Vec<Element<'a, Message>> = Vec::with_capacity(3);
         if self.pane_restartable(pane) {
             controls.push(pane_header_button(
                 iced_fonts::lucide::refresh_cw(),
@@ -954,6 +954,15 @@ impl Oryxis {
                 Message::Terminal(TerminalMessage::RestartPane(pane_id)),
             ));
         }
+        // Break this pane out into a tab of its own (issue #208 item 4).
+        // Before close, in the same order the pane's own menu puts them:
+        // the two answers to "this pane should not be here", the one
+        // that keeps the session ahead of the one that ends it.
+        controls.push(pane_header_button(
+            iced_fonts::lucide::external_link(),
+            t("pane_to_new_tab"),
+            Message::Terminal(TerminalMessage::MovePaneToNewTab(pane_id)),
+        ));
         controls.push(pane_header_button(
             iced_fonts::lucide::x(),
             t("close_pane"),

--- a/crates/oryxis-app/src/views/terminal.rs
+++ b/crates/oryxis-app/src/views/terminal.rs
@@ -978,12 +978,25 @@ impl Oryxis {
         } else {
             colors.bg_surface
         };
-        iced::widget::pane_grid::TitleBar::new(
+        // Right-click the NAME for the pane's own menu. Deliberately the
+        // title and not the whole strip: the drag pick area is the bar
+        // minus its title and minus its controls, so a target that
+        // filled the bar would leave nothing to grab. A right press
+        // never starts a drag either way, so the two gestures share the
+        // strip without competing.
+        //
+        // This is the route that does not care what `terminal_right_click`
+        // is set to. The canvas offers the same menu only under the Menu
+        // scheme; the header is not the canvas.
+        let title: Element<'a, Message> = MouseArea::new(
             container(dir_row(title).align_y(iced::Alignment::Center))
                 .height(Length::Fixed(PANE_HEADER_HEIGHT))
                 .padding(Padding::from([0.0, 8.0]))
                 .center_y(Length::Fixed(PANE_HEADER_HEIGHT)),
         )
+        .on_right_press(Message::Terminal(TerminalMessage::ShowPaneHeaderMenu(pane_id)))
+        .into();
+        iced::widget::pane_grid::TitleBar::new(title)
         .controls(iced::widget::pane_grid::Controls::new(
             container(dir_row(controls).align_y(iced::Alignment::Center))
                 .height(Length::Fixed(PANE_HEADER_HEIGHT))

--- a/crates/oryxis-app/tests/e2e/pane-out-of-grid.ice
+++ b/crates/oryxis-app/tests/e2e/pane-out-of-grid.ice
@@ -1,0 +1,119 @@
+viewport: 1200x750
+mode: Zen
+-----
+# Issue #208 item 4, the two gestures that take a pane OUT of its grid:
+# dragged by its header onto another tab's chip, and broken out into a
+# tab of its own by each of its four doors (tab menu, header menu, the
+# chord, the header button). Same prologue as pane-drag.ice: headers on
+# through the settings search, then a split of two local shells.
+#
+# The pane that travels is KILLED first, so every landing can be told
+# apart from a rebuild: a moved pane still carries its verdict, in its
+# header when it lands in a split and as the end-of-session card when it
+# lands alone.
+#
+# "Broadcast" is the status-bar segment a SPLIT tab shows and a lone one
+# does not, so it doubles as "which tab is on screen": after the drop it
+# proves the view followed the pane into the destination split (the chip
+# under a release is a button, and a button does not fire on a release
+# whose press began elsewhere, so the app has to select it), and after a
+# break-out its absence proves the new lone tab is the one displayed.
+#
+# Coordinates: (300, 54) is the left pane's header pick area (between
+# the label and the controls); (470, 20) the third chip while the second
+# is displayed; (460, 20) that same chip once it is the active, wider
+# one; (40, 54) the left header's NAME; (566, 54) the left header's
+# break-out button, the middle of its three controls.
+expect "Welcome to Oryxis"
+click "Skip"
+click "Continue without password"
+expect "Create host"
+click (1168, 55)
+expect "Terminal Settings"
+click (95, 68)
+type "title bar"
+settle 400
+expect "Title bar on each pane"
+type enter
+settle 500
+click (1140, 70)
+settle 400
+click (333, 20)
+expect "Local Shell"
+timeout 800
+click "Local Shell"
+settle 900
+type ctrl+shift+d
+settle 800
+click "Local Shell"
+settle 1200
+# Kill the LEFT pane: it is the one every gesture below moves.
+click (200, 300)
+settle 300
+type "exit"
+type enter
+settle 1400
+expect "bash (default) (disconnected)"
+expect "Broadcast"
+# A third tab to drop onto, then back to the split.
+click (438, 11)
+expect "Local Shell"
+click "Local Shell"
+settle 1200
+absent "Broadcast"
+click (283, 20)
+settle 800
+expect "Broadcast"
+# Drag the dead pane by its header onto the third tab's chip. The two
+# moves clear iced's 10 px drag deadband before the strip is reached.
+press (300, 54)
+settle 200
+move (340, 70)
+settle 200
+move (470, 20)
+settle 400
+release (470, 20)
+settle 900
+# The view followed the pane into the destination split, and the pane
+# arrived whole: its header still says how its session ended.
+expect "Broadcast"
+expect "bash (default) (disconnected)"
+screenshot pane-out-of-grid-dropped
+# Tab menu: the arriving pane took the focus, so the row breaks it out
+# again, into a lone tab of its own where its card answers for it.
+click right (460, 20)
+settle 300
+expect "Move to a new tab"
+click "Move to a new tab"
+settle 900
+absent "Broadcast"
+expect "Session ended"
+# Header menu: right-click on the pane's NAME raises its whole menu,
+# whatever the terminal does with a right-click.
+type ctrl+shift+d
+settle 600
+click "Local Shell"
+settle 1200
+expect "Broadcast"
+click right (40, 54)
+settle 300
+expect "Move to a new tab"
+type escape
+settle 300
+# The chord acts on the focused pane, which the right-click just made
+# the dead one.
+type ctrl+alt+p
+settle 900
+absent "Broadcast"
+expect "Session ended"
+# The header button, on the same pane after one more split.
+type ctrl+shift+d
+settle 600
+click "Local Shell"
+settle 1200
+expect "Broadcast"
+click (566, 54)
+settle 900
+absent "Broadcast"
+expect "Session ended"
+screenshot pane-out-of-grid-end


### PR DESCRIPTION
Closes the rest of #208 item 4: a pane can leave the grid it is in, either into a tab of its own or into another tab. Builds on 79622788, which did the in-grid rearrange.

Both are MOVES. Nothing is torn down on either path: no `session.close()`, no ended log row, no `monitor_reset_host`, no `prune_quick_connects`. The pane travels whole, carrying its session, its recording, its scrollback and its origin, so what was running keeps running and the recording keeps writing to the row it already had. The only thing carried separately is `ssm_keepalive`, which is per TAB rather than per pane, so a pane leaving a keepalive tab would otherwise start idling out; the same carry `merge_dragged_tab_if_proposed` makes in the opposite direction.

## What a tab owes when a pane leaves it

`TerminalTab::take_pane`, shared with the close path rather than written twice. The three repairs you named, each of which was its own bug once: focus moves to the promoted sibling but only if the pane that left held it, broadcast disarms once the tab can no longer show its controls, and the label re-anchors on the survivor (#108). Closing and moving owe exactly these and differ only in the caller's own bookkeeping.

A source emptied to zero is unreachable rather than handled: a lone pane grows no header, so there is no handle to drag and the menu row is not offered. The guard is there anyway, since the overlay is not modal and can outlive the split it was raised on.

## Into a tab of its own

Four routes, deliberately, because the pane's own context menu only exists under the Menu right-click scheme and most people leave right-click on Paste:

- the pane's context menu, on the pane you clicked
- the TAB's context menu, on the focused pane, beside the zoom that is already there on the same terms
- a button in the pane header, beside restart and close
- `Ctrl+Alt+D`, reading off `Ctrl+Shift+D` for a split: the same D one modifier along, for the pane leaving rather than arriving

Right-clicking the pane header also raises that pane's whole menu, so zoom, flip, restart and close come with it on a terminal whose right-click pastes. On the NAME rather than the whole strip: the pick area is the bar minus its title and minus its controls, so a target filling the bar would leave nothing to grab. A right press never starts a drag, so the two gestures share the strip without competing.

The new tab is appended and placed with `TabPlacement::NextToOriginal` rather than spliced into `Oryxis::tabs`, which is append-only by design so no `active_tab` / `last_terminal_tab` / `connecting.tab_idx` index goes stale.

One note on the header button: it costs pick area, so the drag handle is narrower with three controls than two. Both sides are still Shrink and the label truncates at 42 characters, so there is grab left on any pane wide enough to read, but it is the reason not to keep adding buttons there. Happy to drop it if you would rather the header stayed at two.

## Into another tab

Drag the pane by its header onto that tab's chip. The inverse of a tab dropped into a grid, and it ends in the same `insert_panes`.

`Canceled` is the hook: the release that landed on no pane is also the release that landed on the strip, and the widget publishes it there because it hit-tests only its own panes. Reachable at all because a pane drag captures nothing, so cursor motion still reaches the strip and `hover.tab` is live throughout, the same signal the tab reorder already rides.

The source tab is recorded when the pane is PICKED UP, and both halves of why are load-bearing. A `pane_grid::Pane` handle is minted per grid and unique only within one, so the tab cannot be found by searching for the handle afterwards. And `active_tab` cannot stand in: that same release also reaches the destination chip's own button, which fires on the release rather than the press, so by the time the drag event is handled the active tab may already BE the destination. That is also why nothing here sets `active_tab`: the view follows the pane because the chip selected itself.

A chip names WHICH tab and nothing about where in it, so the pane lands on the destination's trailing edge rather than splitting whichever pane happens to be focused in a tab that is not on screen.

## Conventions

One new i18n key in all 23 language modules, reused by the menu rows and the hotkey label rather than minting parallel keys. The hotkey is in `HotkeyAction::ALL`, its code table, `terminal_only` and the palette category, so it is rebindable and searchable. Three tests: what a broken-out pane keeps, what a tab settles when a pane leaves it, and that a pane moved between tabs lands whole on the trailing edge.

## Testing

`cargo check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace --lib --bins` all clean on Windows 11.

Exercised by hand: all four break-out routes; the drag onto another chip; the source settling behind both (survivor focused, tab renamed, broadcast disarmed); a background pane leaving without moving the keyboard; the row absent on an unsplit tab; and a live session surviving every one of them. Not yet exercised on macOS or Linux.
