### PR TITLE
fix(sync): set actual paired device name from settings

### DIFF
--- a/crates/oryxis-sync/src/crypto.rs
+++ b/crates/oryxis-sync/src/crypto.rs
@@ -110,7 +110,9 @@ impl DeviceIdentity {
     ///
     /// `fallback_device_name` is used only when generating a new
     /// identity; when loading an existing one, the name embedded in
-    /// the blob wins.
+    /// the blob wins. That embedded name is NOT what peers are told —
+    /// it is written once and would freeze a device under whatever
+    /// name it had at first start; see [`advertised_device_name`].
     pub fn load_or_generate(
         vault: &oryxis_vault::VaultStore,
         fallback_device_name: &str,
@@ -126,6 +128,22 @@ impl DeviceIdentity {
             .set_sync_device_identity(&fresh.to_bytes())
             .map_err(|e| SyncError::Vault(e.to_string()))?;
         Ok(fresh)
+    }
+}
+
+/// The name this device advertises to a peer right now.
+///
+/// The identity blob embeds a name, but it is written exactly once —
+/// at generation, which happens on the first engine start, typically
+/// before the user has typed anything into Device Name — and renaming
+/// must never mean regenerating the identity (that would orphan every
+/// paired peer). So the live `sync_device_name` setting wins whenever
+/// it holds something, and the blob's name is only the fallback for a
+/// vault where the field was never filled in.
+pub fn advertised_device_name(vault: &oryxis_vault::VaultStore, identity: &DeviceIdentity) -> String {
+    match vault.get_setting("sync_device_name") {
+        Ok(Some(name)) if !name.trim().is_empty() => name.trim().to_string(),
+        _ => identity.device_name.clone(),
     }
 }
 

--- a/crates/oryxis-sync/src/engine/pairing.rs
+++ b/crates/oryxis-sync/src/engine/pairing.rs
@@ -66,9 +66,17 @@ pub(super) async fn run_pairing_as_joiner(
     // `x25519_dh` so the ephemeral private key is forgotten.
     let (joiner_x25519_secret, joiner_x25519_pub) = crypto::x25519_keypair();
 
+    // Read the name off the vault rather than off the cached identity:
+    // the identity is a snapshot taken when the engine started, and the
+    // user may well have filled in Device Name since (or ever).
+    let device_name = {
+        let v = vault.lock().map_err(|_| SyncError::Vault("Lock".into()))?;
+        crypto::advertised_device_name(&v, identity)
+    };
+
     transport.send(&SyncMessage::PairingRequest {
         device_id: identity.device_id,
-        device_name: identity.device_name.clone(),
+        device_name,
         public_key: identity.public_key_bytes(),
         pairing_code: code.to_string(),
         listen_port,
@@ -244,6 +252,7 @@ pub(super) async fn handle_pairing_request(
     // joiner's source IP + advertised listen port; relay has neither
     // (we'll sync via relay forever for this peer).
     let now = chrono::Utc::now();
+    let our_name;
     {
         let v = vault.lock().map_err(|_| SyncError::Vault("Lock".into()))?;
         v.save_sync_peer(
@@ -256,6 +265,9 @@ pub(super) async fn handle_pairing_request(
         if let Some((addr, listen_port)) = peer_endpoint {
             v.update_sync_peer_endpoint(&device_id, &addr.ip().to_string(), listen_port)?;
         }
+        // Under the same lock: the name we send back is read here, not
+        // taken from the engine-start snapshot in `identity`.
+        our_name = crypto::advertised_device_name(&v, identity);
     }
     if let Ok(mut state) = hosting_pairing.lock() {
         *state = None;
@@ -263,7 +275,7 @@ pub(super) async fn handle_pairing_request(
 
     transport.send(&SyncMessage::PairingAccepted {
         device_id: identity.device_id,
-        device_name: identity.device_name.clone(),
+        device_name: our_name,
         public_key: identity.public_key_bytes(),
         x25519_pub: host_x25519_pub.to_vec(),
     }).await?;

--- a/crates/oryxis-sync/src/tests.rs
+++ b/crates/oryxis-sync/src/tests.rs
@@ -385,6 +385,78 @@ mod tests {
         assert_eq!(joiner_secret, host_secret);
     }
 
+    /// Regression: the name a peer records at pairing time must be the
+    /// one currently set in Settings, not the one that happened to be
+    /// in the identity blob when it was first generated. The identity
+    /// is written exactly once (first engine start, typically before
+    /// the user has typed anything, so it carries the `oryxis-device`
+    /// fallback) and a rename must not require regenerating it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pairing_advertises_the_renamed_device_not_the_identity_blob() {
+        let (host, host_port) = started_engine("oryxis-device");
+        let (joiner, _) = started_engine("oryxis-device");
+        let host_id = host.identity().device_id;
+        let joiner_id = joiner.identity().device_id;
+
+        // Both engines are already running when the user fills in
+        // Device Name; no restart follows.
+        host.vault
+            .lock()
+            .unwrap()
+            .set_setting("sync_device_name", "work-desktop")
+            .unwrap();
+        joiner
+            .vault
+            .lock()
+            .unwrap()
+            .set_setting("sync_device_name", "travel-laptop")
+            .unwrap();
+
+        let code = host.handle().start_hosting_pairing();
+        joiner
+            .handle()
+            .join_pairing(loopback(host_port), code)
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let joiner_peers = joiner.vault.lock().unwrap().list_sync_peers().unwrap();
+        assert_eq!(joiner_peers.len(), 1);
+        assert_eq!(joiner_peers[0].peer_id, host_id);
+        assert_eq!(joiner_peers[0].device_name, "work-desktop");
+
+        let host_peers = host.vault.lock().unwrap().list_sync_peers().unwrap();
+        assert_eq!(host_peers.len(), 1);
+        assert_eq!(host_peers[0].peer_id, joiner_id);
+        assert_eq!(host_peers[0].device_name, "travel-laptop");
+    }
+
+    /// The advertised name falls back to the identity blob only when
+    /// the setting is absent or blank, so a vault that never had the
+    /// field filled keeps advertising what it always did.
+    #[test]
+    fn advertised_device_name_prefers_the_setting_over_the_blob() {
+        let vault = test_vault();
+        let identity = DeviceIdentity::load_or_generate(&vault, "oryxis-device").unwrap();
+        assert_eq!(
+            crate::crypto::advertised_device_name(&vault, &identity),
+            "oryxis-device"
+        );
+
+        vault.set_setting("sync_device_name", "  work-desktop ").unwrap();
+        assert_eq!(
+            crate::crypto::advertised_device_name(&vault, &identity),
+            "work-desktop"
+        );
+
+        // Clearing the field must not put an empty name on the wire.
+        vault.set_setting("sync_device_name", "   ").unwrap();
+        assert_eq!(
+            crate::crypto::advertised_device_name(&vault, &identity),
+            "oryxis-device"
+        );
+    }
+
     /// A wrong code is rejected and neither side stores a peer.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn pairing_rejects_wrong_code() {


### PR DESCRIPTION
### Problem

When pairing a new device over P2P sync, the peer is always registered under the name `oryxis-device`, no matter what the user actually typed into Device Name in Settings.

### Cause

The device's name lives in two places that fell out of sync:

1. The identity blob (DeviceIdentity, persisted encrypted in the vault) embeds a device_name — but it is written exactly once, on first engine start, via DeviceIdentity::load_or_generate(). At that point sync.device_name is normally still empty (the user hasn't opened Settings yet), so the fallback literal "oryxis-device" gets baked into the blob permanently.
2. The pairing handshake (PairingRequest / PairingAccepted in engine/pairing.rs) sent identity.device_name — i.e. that frozen blob value — to the peer, completely ignoring whatever the user later typed into the Device Name field.

The sync_device_name setting itself was updated correctly on every keystroke, but nothing ever fed it back into the identity or the pairing wire messages. Renaming the device in Settings changed the UI and the local setting, but had zero effect on what was actually advertised to peers.

### Solution

- Added advertised_device_name(vault, identity) in crypto.rs: it reads the live sync_device_name setting at the moment it's needed, falling back to the identity blob's name only if the setting is empty/unset.
- Both PairingRequest (joiner side) and PairingAccepted (host side) in engine/pairing.rs now call this helper instead of reading identity.device_name directly, so pairing always advertises the current name.
- No changes to device_id or the Ed25519 signing key — the identity itself is untouched, so already-paired peers are unaffected and no engine restart is required for a rename to take effect on the next pairing.
- Added regression tests in tests.rs:
  - pairing_advertises_the_renamed_device_not_the_identity_blob — two live engines start with the oryxis-device fallback, the name is changed in settings afterward, and pairing is verified to carry the new name on both sides.
  - advertised_device_name_prefers_the_setting_over_the_blob — covers the setting-over-blob precedence, trimming, and the empty-setting fallback.

**Known limitation:** a device already paired before this fix keeps showing the stale oryxis-device name on its peer's side — only the pairing handshake carries the name today, not regular sync sessions. Re-pairing (or a future change to propagate the name over the session Hello, bumping PROTOCOL_VERSION) is needed to fix already-paired peers.
Also, given this solution, the `device_name` field in `DeviceIdentity` becomes redundant. It seems we could either drop it (though that breaks backward compatibility), or make it so that on the application's first start the device name is taken from the hostname, falling back to the literal `oryxis-device`.